### PR TITLE
fix(cloud-only): always scale power fields kW->W (#42) — release 1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ChargePower` / `HousePower` (and `FVPower`, `BatteryPower`, `GridPower`) showed `W` while the value was actually `kW` in cloud-only (4G) mode** (#42). The cloud→LAN synthesis scaled these power fields by 1000 only when a `voltage`/`voltageinstallation` field happened to be present in the payload and below 10 — an unrelated heuristic that silently skipped the conversion on accounts where that field was absent or out of range. The cloud always reports power measurements in kW, so the kW→W conversion is now applied unconditionally, the same way `ContractedPower` already is.
+
 ## [1.3.3] - 2026-06-17
 
 Maintenance release. No functional change to the integration — runtime code,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.3.4] - 2026-06-26
 
 ### Fixed
 

--- a/custom_components/v2c_cloud/local_api.py
+++ b/custom_components/v2c_cloud/local_api.py
@@ -88,11 +88,13 @@ def _build_local_interval(
     return timedelta(seconds=seconds)
 
 
-# Mapping: cloud reported key (lowercase) → (local RealTimeData key, needs_scale)
+# Mapping: cloud reported key (lowercase) → (local RealTimeData key, is_power_kw)
 #
 # Sources confirmed against real `/device/reported` + `/device/currentstatecharge`
 # payloads on a Trydan XQUXDU running firmware 2.4.6 (see docs/cloud-payload-keys
-# for the dump used during the 2026-05-19 audit).
+# for the dump used during the 2026-05-19 audit). The cloud always reports power
+# measurements in kW; `is_power_kw` marks the fields that need the unconditional
+# kW → W conversion applied (see `_CLOUD_POWER_KW_TO_W` below).
 _REPORTED_TO_REALTIME: dict[str, tuple[str, bool]] = {
     "charge_state": ("ChargeState", False),
     "chargestate": ("ChargeState", False),
@@ -111,8 +113,7 @@ _REPORTED_TO_REALTIME: dict[str, tuple[str, bool]] = {
     # it carries a small internal signal (e.g. 0.077350 on a 230V EU install) that
     # does not correspond to any user-visible electrical quantity. The actual mains
     # / installation voltage is carried in `cp_level` (see below) and we map that
-    # to VoltageInstallation instead. `voltage` is intentionally NOT mapped here
-    # (but is still inspected by _detect_cloud_scale as a magnitude heuristic).
+    # to VoltageInstallation instead. `voltage` is intentionally NOT mapped here.
     "house_power": ("HousePower", True),
     "housepower": ("HousePower", True),
     "sun_power": ("FVPower", True),
@@ -217,19 +218,15 @@ _CLOUD_TO_LAN_MULTIPLIERS: dict[str, int] = {
     "LightLED": 100,
 }
 
-
-def _detect_cloud_scale(reported: dict[str, object]) -> float:
-    """Detect if cloud values are in kW/kV vs W/V using voltage as indicator."""
-    for key in ("voltage", "voltageinstallation"):
-        raw = reported.get(key)
-        if raw is not None:
-            try:
-                v = float(str(raw))
-                if 0 < v < 10:  # noqa: PLR2004 — voltage in kV would be < 10 V
-                    return 1000  # kV → V
-            except (ValueError, TypeError):
-                pass
-    return 1
+# All power measurements (ChargePower, HousePower, FVPower, BatteryPower,
+# GridPower) are reported by the cloud in kW, while the LAN /RealTimeData
+# convention — and the entity layer hard-coded to it — uses W. Previously this
+# was scaled via a heuristic that inferred kW vs W from the magnitude of the
+# unrelated `voltage` field; that field doesn't correlate with the power unit
+# and left the conversion unapplied whenever it was absent or out of range
+# (e.g. issue #42, where ChargePower/HousePower stayed in kW but were labelled
+# as W). The conversion is now applied unconditionally, like ContractedPower.
+_CLOUD_POWER_KW_TO_W = 1000
 
 
 def _build_realtime_from_reported(
@@ -253,10 +250,9 @@ def _build_realtime_from_reported(
         return {"_data_source": "cloud_reported_empty", "_lower_index": {}}
 
     reported_lower = {k.lower(): v for k, v in reported.items()}
-    scale = _detect_cloud_scale(reported_lower)
     result: dict[str, Any] = {"_data_source": "cloud_reported"}
 
-    for cloud_key, (local_key, needs_scale) in _REPORTED_TO_REALTIME.items():
+    for cloud_key, (local_key, is_power_kw) in _REPORTED_TO_REALTIME.items():
         if local_key in result:
             continue
         raw = reported_lower.get(cloud_key)
@@ -266,8 +262,8 @@ def _build_realtime_from_reported(
             value = float(str(raw))
         except (ValueError, TypeError):
             continue
-        if needs_scale:
-            value = value * scale
+        if is_power_kw:
+            value = value * _CLOUD_POWER_KW_TO_W
         multiplier = _CLOUD_TO_LAN_MULTIPLIERS.get(local_key)
         if multiplier is not None:
             value = value * multiplier
@@ -277,8 +273,7 @@ def _build_realtime_from_reported(
     csc = device_state.get("additional", {}).get("currentstatecharge")
     if isinstance(csc, dict):
         csc_lower = {k.lower(): v for k, v in csc.items()}
-        csc_scale = _detect_cloud_scale(csc_lower)
-        for cloud_key, (local_key, needs_scale) in _REPORTED_TO_REALTIME.items():
+        for cloud_key, (local_key, is_power_kw) in _REPORTED_TO_REALTIME.items():
             if local_key in result:
                 continue
             raw = csc_lower.get(cloud_key)
@@ -288,8 +283,8 @@ def _build_realtime_from_reported(
                 value = float(str(raw))
             except (ValueError, TypeError):
                 continue
-            if needs_scale:
-                value = value * csc_scale
+            if is_power_kw:
+                value = value * _CLOUD_POWER_KW_TO_W
             multiplier = _CLOUD_TO_LAN_MULTIPLIERS.get(local_key)
             if multiplier is not None:
                 value = value * multiplier

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/tests/test_synthesis_cloud_only.py
+++ b/tests/test_synthesis_cloud_only.py
@@ -123,8 +123,7 @@ class TestVoltageInstallationMapping:
     """The mains/installation voltage comes from `cp_level` in cloud payloads
     (e.g. 248 V on a 230 V EU install). The cloud's `voltage` field carries
     a small internal signal (e.g. 0.077350) that does NOT correspond to the
-    mains voltage, so it is intentionally NOT mapped — but it is still used
-    by `_detect_cloud_scale` as a magnitude heuristic for power fields."""
+    mains voltage, so it is intentionally NOT mapped."""
 
     # A minimal /reported is required because _build_realtime_from_reported
     # short-circuits on an empty reported dict (the synthesis pipeline is
@@ -140,9 +139,9 @@ class TestVoltageInstallationMapping:
 
     def test_cloud_voltage_field_not_mapped(self) -> None:
         # Regression: pre-fix the cloud `voltage` field (= 0.077350) was
-        # scaled by 1000 in _detect_cloud_scale and surfaced as 77.35 V, a
-        # spurious mains-voltage reading. After the fix this field MUST be
-        # ignored as a voltage source.
+        # scaled by 1000 and surfaced as 77.35 V, a spurious mains-voltage
+        # reading. After the fix this field MUST be ignored as a voltage
+        # source.
         runtime = _runtime_with_reported_and_csc(
             self._PROBE_REPORTED,
             {"voltage": "0.077350"},
@@ -286,7 +285,7 @@ class TestFullPayloadFromRealDevice:
         # real-time telemetry
         "seconds": "26711",
         "error": "0",
-        "voltage": "0.072800",  # cloud reports kV → scale 1000
+        "voltage": "0.072800",  # internal signal, not mains voltage; unused by power scaling
         "phases": "0",
         "battery": "0.000000",
         "intensity": "0",  # csc has *live* intensity, /reported has setpoint
@@ -327,9 +326,44 @@ class TestFullPayloadFromRealDevice:
         assert result["ChargeState"] == 2  # from /csc
         assert result["ChargeTime"] == 26711  # seconds
         assert result["ChargeEnergy"] == 4.18
-        # Power values scaled from kW → W (heuristic triggers because the
-        # cloud `voltage` field — not real voltage — has magnitude < 10).
+        # Power values unconditionally scaled from kW → W.
         assert result["HousePower"] == 212.0
         # VoltageInstallation now sourced from `cp_level` (actual mains
         # voltage in V); the cloud `voltage` field is intentionally ignored.
         assert result["VoltageInstallation"] == 248.0
+
+
+class TestPowerFieldsAlwaysScaledKwToW:
+    """Regression for issue #42: ChargePower/HousePower showed as W while the
+    value was actually in kW. The old `_detect_cloud_scale` heuristic only
+    applied the kW->W conversion when a `voltage`/`voltageinstallation` field
+    happened to be present and below 10 — accounts without that field (or
+    with it outside that range) got the raw kW value mislabelled as W. Power
+    fields must scale unconditionally, regardless of the `voltage` field."""
+
+    def test_house_power_scales_without_voltage_field(self) -> None:
+        runtime = _runtime_with_reported({"house_power": "0.212000"})
+        result = _build_realtime_from_reported(runtime, "dev1")
+        assert result["HousePower"] == 212.0
+
+    def test_charge_power_scales_without_voltage_field(self) -> None:
+        runtime = _runtime_with_reported({"power": "3.456000"})
+        result = _build_realtime_from_reported(runtime, "dev1")
+        assert result["ChargePower"] == 3456.0
+
+    def test_fv_power_scales_without_voltage_field(self) -> None:
+        runtime = _runtime_with_reported({"sun_power": "1.500000"})
+        result = _build_realtime_from_reported(runtime, "dev1")
+        assert result["FVPower"] == 1500.0
+
+    def test_battery_power_scales_without_voltage_field(self) -> None:
+        runtime = _runtime_with_reported({"battery": "0.500000"})
+        result = _build_realtime_from_reported(runtime, "dev1")
+        assert result["BatteryPower"] == 500.0
+
+    def test_house_power_scales_even_when_voltage_is_out_of_range(self) -> None:
+        # voltage >= 10 used to defeat the old heuristic and leave the
+        # power value unscaled.
+        runtime = _runtime_with_reported({"house_power": "0.212000", "voltage": "230"})
+        result = _build_realtime_from_reported(runtime, "dev1")
+        assert result["HousePower"] == 212.0


### PR DESCRIPTION
## Summary
- `ChargePower` / `HousePower` (and `FVPower`, `BatteryPower`, `GridPower`) were reported with unit `W` while the actual value was in `kW`, in cloud-only (4G) mode.
- Root cause: the cloud→LAN synthesis only scaled these power fields by 1000 when a `voltage`/`voltageinstallation` field happened to be present in the payload and below 10 — an unrelated heuristic (`_detect_cloud_scale`) that silently skipped the conversion on accounts where that field was absent or out of range.
- Fix: the cloud always reports power measurements in kW, so the kW→W conversion is now applied **unconditionally**, the same way `ContractedPower` already is. The heuristic and its `scale`/`csc_scale` plumbing have been removed.
- Bumps `manifest.json` to `1.3.4` and finalizes the changelog entry so merging to `main` triggers the release pipeline.

Fixes #42

## Test plan
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Full test suite passing (479 tests), including new regression coverage in `TestPowerFieldsAlwaysScaledKwToW` for `HousePower`/`ChargePower`/`FVPower`/`BatteryPower` with the `voltage` field absent or out of range
- [x] Branch rebased on latest `main` (includes the 4 just-merged Dependabot bumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015vyziuqhWm2bRycfXNdFJq)_