### PR TITLE
chore(release): 1.3.5 — re-publish after v1.3.4 tag/release deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.5] - 2026-06-26
+
+Re-publish release. The `v1.3.4` git tag and GitHub Release were deleted
+manually after publishing. No functional change to the integration — runtime
+code, entities and the config-entry schema are identical to `1.3.4`. This
+bump exists solely to re-trigger `tag-and-release.yaml` so the tag, release
+and SBOM artifacts (`v2c_cloud.zip`, `.spdx.json`, `.cyclonedx.json`) exist
+again for HACS.
+
 ## [1.3.4] - 2026-06-26
 
 ### Fixed

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.3.4"
+  "version": "1.3.5"
 }


### PR DESCRIPTION
## Why

The `v1.3.4` git tag and GitHub Release were deleted manually after publishing. `tag-and-release.yaml` only creates a tag/release when one doesn't already exist for the version in `manifest.json`, so simply re-pushing the same version wouldn't re-trigger it.

## What

Bump to `1.3.5` (no functional/runtime change vs `1.3.4`) so the release pipeline runs again and republishes the tag, GitHub Release, and SBOM artifacts (`v2c_cloud.zip`, `.spdx.json`, `.cyclonedx.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vyziuqhWm2bRycfXNdFJq)_