### PR TITLE
Revert "chore(release): 1.3.5" — re-publish v1.3.4 instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.3.5] - 2026-06-26
-
-Re-publish release. The `v1.3.4` git tag and GitHub Release were deleted
-manually after publishing. No functional change to the integration — runtime
-code, entities and the config-entry schema are identical to `1.3.4`. This
-bump exists solely to re-trigger `tag-and-release.yaml` so the tag, release
-and SBOM artifacts (`v2c_cloud.zip`, `.spdx.json`, `.cyclonedx.json`) exist
-again for HACS.
-
 ## [1.3.4] - 2026-06-26
 
 ### Fixed

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.3.5"
+  "version": "1.3.4"
 }


### PR DESCRIPTION
## Why

#44 bumped to `1.3.5` to re-trigger `tag-and-release.yaml` after the `v1.3.4` tag/release were deleted manually. That was the wrong call — the request was to re-publish `v1.3.4` itself, not ship a new version.

## What

Reverts #44 (`manifest.json` back to `1.3.4`, removes the `1.3.5` changelog entry). Since the `v1.3.4` tag no longer exists, this push to `main` will make `tag-and-release.yaml` recreate tag `v1.3.4` and its GitHub Release (with the SBOM + zip assets) again, pointing at the current `main` HEAD — same code, same changelog section, just republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015vyziuqhWm2bRycfXNdFJq)_