### PR TITLE
chore(release): 1.3.5 — drop SBOM release assets, supersede 1.3.4

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -162,32 +162,6 @@ jobs:
           cd "${{ github.workspace }}/custom_components/v2c_cloud"
           zip v2c_cloud.zip -r ./
 
-      # Generate a Software Bill of Materials in both SPDX-JSON and CycloneDX
-      # formats so downstream consumers (HACS users, security scanners) can
-      # consume whichever standard they prefer. The action scans the integration
-      # source tree directly, including the dependency manifest files.
-      - name: Generate SBOM (SPDX-JSON)
-        if: env.EXISTS == 'false'
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
-        with:
-          path: ${{ github.workspace }}
-          format: spdx-json
-          artifact-name: v2c_cloud-${{ env.VERSION }}.spdx.json
-          output-file: ${{ github.workspace }}/v2c_cloud-${{ env.VERSION }}.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
-      - name: Generate SBOM (CycloneDX-JSON)
-        if: env.EXISTS == 'false'
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
-        with:
-          path: ${{ github.workspace }}
-          format: cyclonedx-json
-          artifact-name: v2c_cloud-${{ env.VERSION }}.cyclonedx.json
-          output-file: ${{ github.workspace }}/v2c_cloud-${{ env.VERSION }}.cyclonedx.json
-          upload-artifact: false
-          upload-release-assets: false
-
       - name: Create GitHub Release
         if: env.EXISTS == 'false'
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
@@ -202,5 +176,3 @@ jobs:
           prerelease: ${{ env.IS_PRERELEASE == 'true' }}
           files: |
             ${{ github.workspace }}/custom_components/v2c_cloud/v2c_cloud.zip
-            ${{ github.workspace }}/v2c_cloud-${{ env.VERSION }}.spdx.json
-            ${{ github.workspace }}/v2c_cloud-${{ env.VERSION }}.cyclonedx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.3.4] - 2026-06-26
+## [1.3.5] - 2026-06-26
 
 ### Fixed
 
 - **`ChargePower` / `HousePower` (and `FVPower`, `BatteryPower`, `GridPower`) showed `W` while the value was actually `kW` in cloud-only (4G) mode** (#42). The cloud→LAN synthesis scaled these power fields by 1000 only when a `voltage`/`voltageinstallation` field happened to be present in the payload and below 10 — an unrelated heuristic that silently skipped the conversion on accounts where that field was absent or out of range. The cloud always reports power measurements in kW, so the kW→W conversion is now applied unconditionally, the same way `ContractedPower` already is.
+
+### Removed
+
+- **SBOM assets (SPDX-JSON / CycloneDX-JSON) no longer attached to releases.** Since they were introduced in `1.3.0`, every release shipped 3 assets instead of 1 (`v2c_cloud.zip` plus the two SBOM files). HACS' download counter reads `download_count` from the release's asset list and is known to pick the wrong entry when more than one asset is present (see [hacs/integration#4438](https://github.com/hacs/integration/issues/4438)), which tracked with the integration's HACS download count going blank. Releases now publish only `v2c_cloud.zip`.
 
 ## [1.3.3] - 2026-06-17
 

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.3.4"
+  "version": "1.3.5"
 }


### PR DESCRIPTION
## Summary
- Releases now publish only `v2c_cloud.zip` — drops the SPDX-JSON / CycloneDX-JSON SBOM assets that every release shipped since `1.3.0`.
- HACS' download counter is known to misread `download_count` when a release has more than one asset ([hacs/integration#4438](https://github.com/hacs/integration/issues/4438)); this lines up with the integration's HACS download count going blank after the SBOM assets were introduced.
- `1.3.4` is treated as superseded by `1.3.5`: the changelog entry is renamed (no functional change beyond the SBOM removal), and the `1.3.4` tag/release is being deleted manually.

## Test plan
- [x] `ruff check .` / `ruff format --check .`
- [x] `python -m pytest tests/` (479 passed)
- [ ] Confirm `tag-and-release.yaml` publishes `v1.3.5` with a single `v2c_cloud.zip` asset


---
_Generated by [Claude Code](https://claude.ai/code/session_015vyziuqhWm2bRycfXNdFJq)_