### PR TITLE
fix(config): read entry.data as a Mapping — 1.4.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
   Home Assistant instance, so a LAN entry stayed offline even with an address
   configured. Home Assistant exposes `entry.data` as a `mappingproxy`, which is
   not a `dict` subclass, and the type guard rejected it.
+- Chargers discovered by the cloud while the options dialog was open were
+  discarded when it was saved. The options flow now merges its own edits into
+  the current configuration instead of the snapshot taken when it opened.
 
 ## [1.4.0-beta.2] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0-beta.3] - 2026-09-11
+
+### Fixed
+
+- Manual IP overrides and the cached address book were never read on a running
+  Home Assistant instance, so a LAN entry stayed offline even with an address
+  configured. Home Assistant exposes `entry.data` as a `mappingproxy`, which is
+  not a `dict` subclass, and the type guard rejected it.
+
 ## [1.4.0-beta.2] - 2026-09-11
 
 ### Fixed

--- a/custom_components/v2c_cloud/config_flow.py
+++ b/custom_components/v2c_cloud/config_flow.py
@@ -394,13 +394,13 @@ class V2COptionsFlow(config_entries.OptionsFlow):
         self._config_entry = config_entry
         self._pending_devices: list[str] = []
         self._manual_ips: dict[str, str] = {}
-        self._pending_data: dict[str, Any] = {}
+        self._pending_changes: dict[str, Any] = {}
         self._pending_options: dict[str, Any] = {}
         self._mode_changed: bool = False
 
     def _apply(
         self,
-        new_data: dict[str, Any],
+        changes: dict[str, Any],
         new_options: dict[str, Any],
         *,
         mode_changed: bool,
@@ -413,11 +413,21 @@ class V2COptionsFlow(config_entries.OptionsFlow):
         is still open — rebuilding the coordinators without the addresses the
         user is in the middle of typing.
 
+        ``changes`` carries only the keys this flow actually edited, and they
+        are merged into ``entry.data`` as it stands RIGHT NOW rather than into
+        the snapshot taken when the first step was shown. While the user works
+        through the per-charger forms the cloud coordinator keeps running and
+        may persist a freshly discovered charger into ``cached_pairings``;
+        writing back the snapshot would drop it, and the lost address could
+        leave that charger unreachable the next time the cloud goes down.
+
         ``entry.data`` goes through async_update_entry; ``entry.options`` is
         written by the async_create_entry return value, the canonical HA
         pattern for options-flow output (passing ``data={}`` there would
         overwrite the options just set).
         """
+        new_data = dict(self._config_entry.data)
+        new_data.update(changes)
         self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
 
         if mode_changed:
@@ -460,10 +470,10 @@ class V2COptionsFlow(config_entries.OptionsFlow):
                 if self._pending_devices:
                     return await self.async_step_manual_ip()
 
-                new_data = dict(self._pending_data)
-                new_data[CONF_MANUAL_IPS] = self._manual_ips
+                changes = dict(self._pending_changes)
+                changes[CONF_MANUAL_IPS] = self._manual_ips
                 return self._apply(
-                    new_data,
+                    changes,
                     self._pending_options,
                     mode_changed=self._mode_changed,
                 )
@@ -512,11 +522,10 @@ class V2COptionsFlow(config_entries.OptionsFlow):
             if not errors and not MIN_LOCAL_INTERVAL <= interval <= MAX_LOCAL_INTERVAL:
                 errors[CONF_LOCAL_UPDATE_INTERVAL] = "invalid_interval"
 
-            new_data = dict(current_data)
             mode_changed = new_mode != current_mode
 
             if not errors:
-                new_data[CONF_CLOUD_ONLY] = new_mode == "cloud_only"
+                changes: dict[str, Any] = {CONF_CLOUD_ONLY: new_mode == "cloud_only"}
 
                 new_options = dict(current_options)
                 new_options[CONF_LOCAL_UPDATE_INTERVAL] = interval
@@ -527,8 +536,7 @@ class V2COptionsFlow(config_entries.OptionsFlow):
                 # Wi-Fi and given its address in a single pass, which matters
                 # most when the cloud is down and cannot supply one.
                 wants_manual = (
-                    user_input.get(CONF_SET_MANUAL_IPS)
-                    and not new_data[CONF_CLOUD_ONLY]
+                    user_input.get(CONF_SET_MANUAL_IPS) and not changes[CONF_CLOUD_ONLY]
                 )
                 if wants_manual and device_ids:
                     # Nothing is persisted yet: forms are still to come, and
@@ -536,12 +544,12 @@ class V2COptionsFlow(config_entries.OptionsFlow):
                     # as it was.
                     self._pending_devices = list(device_ids)
                     self._manual_ips = dict(current_manual)
-                    self._pending_data = new_data
+                    self._pending_changes = changes
                     self._pending_options = new_options
                     self._mode_changed = mode_changed
                     return await self.async_step_manual_ip()
 
-                return self._apply(new_data, new_options, mode_changed=mode_changed)
+                return self._apply(changes, new_options, mode_changed=mode_changed)
 
         schema = vol.Schema(
             {

--- a/custom_components/v2c_cloud/local_api.py
+++ b/custom_components/v2c_cloud/local_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
@@ -400,11 +400,20 @@ async def _async_read_keyword(
         return keyword, None
 
 
-def _entry_data_of(runtime_data: V2CEntryRuntimeData) -> dict[str, Any]:
-    """Return ``entry.data`` as a plain dict, or {} when unavailable."""
+def _entry_data_of(runtime_data: V2CEntryRuntimeData) -> Mapping[str, Any]:
+    """
+    Return ``entry.data``, or an empty mapping when unavailable.
+
+    The type check is against ``Mapping``, NOT ``dict``: Home Assistant hands
+    out ``entry.data`` as a ``types.MappingProxyType``, which is a Mapping but
+    is *not* a dict subclass. An ``isinstance(data, dict)`` guard here silently
+    discarded the real config on every live instance — the manual IP overrides
+    and the cached address book were never read — while passing every test,
+    because the test doubles supplied plain dicts.
+    """
     entry = getattr(runtime_data.coordinator, "config_entry", None)
     data = getattr(entry, "data", None)
-    return data if isinstance(data, dict) else {}
+    return data if isinstance(data, Mapping) else {}
 
 
 def manual_ip_for(runtime_data: V2CEntryRuntimeData, device_id: str) -> str | None:

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.4.0-beta.2"
+  "version": "1.4.0-beta.3"
 }

--- a/tests/test_cloud_outage_resilience.py
+++ b/tests/test_cloud_outage_resilience.py
@@ -17,6 +17,7 @@ genuinely has no second transport — still asks for reauthentication.
 
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -49,10 +50,19 @@ OTHER_IP = "192.168.1.77"
 
 
 def _entry(**data: Any) -> MagicMock:
+    """
+    Build a config-entry double whose ``data`` is a MappingProxyType.
+
+    Home Assistant exposes ``entry.data`` as a mappingproxy, which is a Mapping
+    but NOT a dict subclass. Doubles that hand back a plain dict hide type
+    errors that break every live instance — that is exactly how an
+    ``isinstance(data, dict)`` guard shipped in 1.4.0-beta.2 and silently
+    discarded the manual IP overrides and the cached address book.
+    """
     entry = MagicMock()
     entry.entry_id = "entry-1"
     entry.title = "V2C Cloud"
-    entry.data = data
+    entry.data = MappingProxyType(dict(data))
     return entry
 
 
@@ -375,3 +385,42 @@ class TestAvailabilitySemantics:
     def test_real_lan_payload_keeps_lan_only_keys_available(self):
         sensor = self._sensor(key="SignalStatus", data={"SignalStatus": 3})
         assert sensor.available is True
+
+
+class TestEntryDataIsReadThroughMappingProxy:
+    """
+    Home Assistant hands out ``entry.data`` as a mappingproxy, not a dict.
+
+    Regression cover for 1.4.0-beta.2, where an ``isinstance(data, dict)``
+    guard made the integration ignore both the manual overrides and the cached
+    address book on every real instance while the suite stayed green.
+    """
+
+    def _runtime_with_proxy(self, **data: Any) -> MagicMock:
+        runtime = MagicMock()
+        runtime.coordinator.config_entry.data = MappingProxyType(dict(data))
+        runtime.coordinator.data = None
+        runtime.local_coordinators = {}
+        return runtime
+
+    def test_manual_override_is_read_from_a_mappingproxy(self):
+        runtime = self._runtime_with_proxy(**{CONF_MANUAL_IPS: {DEVICE_ID: LAN_IP}})
+        assert resolve_static_ip(runtime, DEVICE_ID) == LAN_IP
+
+    def test_cached_pairings_are_read_from_a_mappingproxy(self):
+        runtime = self._runtime_with_proxy(
+            **{CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LAN_IP}]}
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == LAN_IP
+
+    def test_transport_reports_the_source_from_a_mappingproxy(self):
+        runtime = self._runtime_with_proxy(**{CONF_MANUAL_IPS: {DEVICE_ID: LAN_IP}})
+        assert describe_ip_source(runtime, DEVICE_ID) == (LAN_IP, "manual")
+
+    def test_a_plain_dict_keeps_working_too(self):
+        """Other callers (and older HA versions) may still pass a real dict."""
+        runtime = MagicMock()
+        runtime.coordinator.config_entry.data = {CONF_MANUAL_IPS: {DEVICE_ID: LAN_IP}}
+        runtime.coordinator.data = None
+        runtime.local_coordinators = {}
+        assert resolve_static_ip(runtime, DEVICE_ID) == LAN_IP

--- a/tests/test_lan_only_setup.py
+++ b/tests/test_lan_only_setup.py
@@ -359,6 +359,49 @@ class TestManualIpSteps:
         await flow.async_step_manual_ip({ATTR_IP_ADDRESS: LAN_IP})
         assert flow.hass.async_create_task.call_count == 1
 
+    async def test_cloud_updates_during_the_flow_are_not_lost(self):
+        """
+        The commit must merge into entry.data as it stands, not a snapshot.
+
+        The cloud coordinator keeps running while the user fills in the
+        per-charger forms and can persist a newly discovered charger into
+        `cached_pairings`. Writing back the snapshot taken at the first step
+        would drop it, and the lost address could leave that charger
+        unreachable the next time the cloud goes down.
+        """
+        entry = self._entry_with(DEVICE_ID)
+        flow = self._flow(entry)
+
+        await flow.async_step_init(
+            {
+                "connection_type": "local",
+                CONF_LOCAL_UPDATE_INTERVAL: 30,
+                CONF_SET_MANUAL_IPS: True,
+            }
+        )
+
+        # Meanwhile the cloud discovers a second charger and persists it.
+        entry.data = MappingProxyType(
+            {
+                **dict(entry.data),
+                CONF_CACHED_PAIRINGS: [
+                    {"deviceId": DEVICE_ID, "ip": "192.168.1.9"},
+                    {"deviceId": "DISCOVERED", "ip": "192.168.1.77"},
+                ],
+            }
+        )
+
+        await flow.async_step_manual_ip({ATTR_IP_ADDRESS: LAN_IP})
+
+        written = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert {p["deviceId"] for p in written[CONF_CACHED_PAIRINGS]} == {
+            DEVICE_ID,
+            "DISCOVERED",
+        }
+        # ...and the flow's own edits are still applied.
+        assert written[CONF_MANUAL_IPS] == {DEVICE_ID: LAN_IP}
+        assert written[CONF_CLOUD_ONLY] is False
+
     def test_known_ids_merge_cache_and_overrides(self):
         entry = _entry(
             **{

--- a/tests/test_lan_only_setup.py
+++ b/tests/test_lan_only_setup.py
@@ -7,6 +7,7 @@ config-flow branch, and the per-charger IP overrides in the options flow.
 
 from __future__ import annotations
 
+from types import MappingProxyType
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -36,7 +37,8 @@ LAN_IP = "192.168.1.50"
 def _entry(**data: Any) -> MagicMock:
     entry = MagicMock()
     entry.entry_id = "entry-1"
-    entry.data = data
+    # mappingproxy, as Home Assistant really exposes it.
+    entry.data = MappingProxyType(dict(data))
     entry.options = {}
     return entry
 


### PR DESCRIPTION
Manual IP overrides and the cached address book were never read on a running instance: Home Assistant exposes `entry.data` as a `types.MappingProxyType`, which is a Mapping but **not** a `dict` subclass, and the guard in `_entry_data_of` checked for `dict`. A LAN entry therefore stayed offline no matter which address was configured.

Found on a live instance: the transport sensor reported `offline` with `ip_address: null` right after an address had been saved, while the options dialog still pre-filled that same address from the very data the integration claimed not to have.

The suite could not catch it — every test double returned a plain dict, so the guard passed in tests and failed in production. Doubles now build `entry.data` with `MappingProxyType`, matching the real type, and a dedicated regression class pins reads through a mappingproxy (plus one case keeping a plain dict working). Re-introducing the old guard fails 6 tests.

572 tests green, ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
