### PR TITLE
fix: cloud-only controls go unavailable when the cloud is out — 1.4.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0-beta.5] - 2026-09-11
+
+### Changed
+
+- Controls that exist only in the V2C cloud API report as unavailable while the
+  cloud is unauthenticated, or on an entry set up without an account: OCPP, the
+  RFID reader, installation type, slave device, language, the reboot and
+  firmware update buttons, and the cloud connectivity sensor. Everything served
+  over the local network keeps working.
+- A switch whose state has never been received reports Unknown instead of Off.
+
+### Fixed
+
+- A command the cloud refuses now surfaces a readable error instead of a
+  traceback, and no longer opens the re-authentication dialog from a service
+  call.
+
 ## [1.4.0-beta.4] - 2026-09-11
 
 ### Changed

--- a/custom_components/v2c_cloud/__init__.py
+++ b/custom_components/v2c_cloud/__init__.py
@@ -266,9 +266,18 @@ def _cached_fallback_payload(
 
 @dataclass
 class _CloudAuthState:
-    """Tracks whether the entry is currently running without cloud auth."""
+    """Tracks whether cloud commands can currently be expected to work."""
 
     degraded: bool = False
+    # A LAN-only entry holds no API key at all. The cloud is not "degraded"
+    # there, it is simply not part of the installation — but the consequence
+    # for a cloud-only control is identical, so it is tracked in one place.
+    absent: bool = False
+
+    @property
+    def usable(self) -> bool:
+        """Whether a request to the V2C Cloud stands a chance of succeeding."""
+        return not (self.degraded or self.absent)
 
 
 def _degraded_cloud_payload(
@@ -464,6 +473,21 @@ class V2CEntryRuntimeData:
     coordinator: DataUpdateCoordinator
     local_coordinators: dict[str, DataUpdateCoordinator] = field(default_factory=dict)
     cloud_only: bool = False
+    cloud_auth: _CloudAuthState = field(default_factory=_CloudAuthState)
+
+    @property
+    def cloud_commands_available(self) -> bool:
+        """
+        Whether a control that can only travel over the cloud can work now.
+
+        Some settings have no LAN equivalent at all — OCPP, the RFID reader,
+        the installation and slave types, the language, reboot and firmware
+        update. When the cloud rejects the API key (issue #54) or the entry
+        has no account in the first place, those controls cannot do anything,
+        and an entity that still offers itself as operable is worse than an
+        absent one: it invites a command that will be silently dropped.
+        """
+        return self.cloud_auth.usable
 
 
 async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
@@ -477,6 +501,7 @@ async def _async_fetch_initial_pairings(
     entry: ConfigEntry,
     client: V2CClient,
     has_cache: bool,
+    auth_state: _CloudAuthState,
 ) -> list[dict[str, Any]]:
     """
     Fetch ``/pairings/me`` at setup, tolerating a cloud that is down.
@@ -502,6 +527,7 @@ async def _async_fetch_initial_pairings(
             "until the cloud authenticates again.",
             len(_lan_addressable_records(entry)),
         )
+        auth_state.degraded = True
         _async_flag_cloud_auth_degraded(hass, entry)
         return []
     except V2CRequestError as err:
@@ -549,6 +575,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         )
     has_cache = bool(cached_pairings)
 
+    # Tracked from here on so that a rejection at startup — not just one during
+    # a later refresh — leaves the cloud-only controls unavailable.
+    auth_state = _CloudAuthState(absent=lan_only)
+
     # Validate credentials and initial connectivity by requesting pairings.
     if lan_only:
         _LOGGER.debug(
@@ -557,7 +587,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         )
         pairings = []
     else:
-        pairings = await _async_fetch_initial_pairings(hass, entry, client, has_cache)
+        pairings = await _async_fetch_initial_pairings(
+            hass, entry, client, has_cache, auth_state
+        )
 
     if not pairings and not has_cache:
         _LOGGER.warning("No V2C devices associated with this API key")
@@ -575,8 +607,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         seconds = math.ceil((device_count * 2 * 86400) / budget)
         seconds = max(seconds, min_seconds)
         return timedelta(seconds=seconds)
-
-    auth_state = _CloudAuthState()
 
     async def _async_update_data() -> dict[str, object]:
         """Fetch the latest data from the API."""
@@ -753,6 +783,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:  #
         client=client,
         coordinator=coordinator,
         cloud_only=is_cloud_only_device(entry.data),
+        cloud_auth=auth_state,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -923,8 +954,14 @@ def _async_register_services(hass: HomeAssistant) -> None:  # noqa: C901
         try:
             result = await call_coroutine
         except V2CAuthError as err:
-            raise ConfigEntryAuthFailed(
-                "Authentication failed during service call"
+            # Deliberately not ConfigEntryAuthFailed: that would open the reauth
+            # dialog from a service call, which is the behaviour this release
+            # removed everywhere else. Whether a rejected key means "reauth" or
+            # "carry on over the LAN" is the coordinator's decision, taken in
+            # one place; a service call only has to report what happened.
+            raise HomeAssistantError(
+                "The V2C Cloud rejected the API key, so this command was not "
+                "delivered to the charger."
             ) from err
         except V2CRequestError as err:
             raise HomeAssistantError(str(err)) from err

--- a/custom_components/v2c_cloud/binary_sensor.py
+++ b/custom_components/v2c_cloud/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -11,6 +11,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .entity import V2CEntity
+
+if TYPE_CHECKING:
+    from . import V2CEntryRuntimeData
 
 
 async def async_setup_entry(
@@ -26,7 +29,7 @@ async def async_setup_entry(
     devices = coordinator.data.get("devices", {}) if coordinator.data else {}
 
     entities: list[BinarySensorEntity] = [
-        V2CConnectedBinarySensor(coordinator, client, device_id)
+        V2CConnectedBinarySensor(coordinator, client, runtime_data, device_id)
         for device_id in devices
     ]
 
@@ -36,12 +39,30 @@ async def async_setup_entry(
 class V2CConnectedBinarySensor(V2CEntity, BinarySensorEntity):
     """Binary sensor indicating if the charger is online."""
 
-    def __init__(self, coordinator: Any, client: Any, device_id: str) -> None:
+    def __init__(
+        self,
+        coordinator: Any,
+        client: Any,
+        runtime_data: V2CEntryRuntimeData,
+        device_id: str,
+    ) -> None:
         """Initialise the binary sensor for the given device."""
         super().__init__(coordinator, client, device_id)
+        self._runtime_data = runtime_data
         self._attr_translation_key = "connected"
         self._attr_unique_id = f"v2c_{device_id}_connected_status"
         self._attr_icon = "mdi:cloud"
+
+    @property
+    def available(self) -> bool:
+        """Return True only while the cloud can answer the question."""
+        # This sensor reports what the CLOUD thinks of the charger, so a dead
+        # cloud leaves it with nothing to report. It must not be read as "the
+        # charger is offline" — the LAN transport may well be working, and the
+        # `Trasporto attivo` sensor is the one that says so.
+        if not self._runtime_data.cloud_commands_available:
+            return False
+        return self.coordinator.last_update_success
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/v2c_cloud/button.py
+++ b/custom_components/v2c_cloud/button.py
@@ -19,6 +19,7 @@ from .local_api import V2CLocalApiError
 from .v2c_cloud import V2CError
 
 if TYPE_CHECKING:
+    from . import V2CEntryRuntimeData
     from .v2c_cloud import V2CClient
 
 
@@ -41,6 +42,7 @@ async def async_setup_entry(
                 V2CButton(
                     coordinator,
                     client,
+                    runtime_data,
                     device_id,
                     name_key="reboot",
                     unique_suffix="reboot",
@@ -53,6 +55,7 @@ async def async_setup_entry(
                 V2CButton(
                     coordinator,
                     client,
+                    runtime_data,
                     device_id,
                     name_key="trigger_update",
                     unique_suffix="trigger_update",
@@ -75,6 +78,7 @@ class V2CButton(V2CEntity, ButtonEntity):
         self,
         coordinator: DataUpdateCoordinator,
         client: V2CClient,
+        runtime_data: V2CEntryRuntimeData,
         device_id: str,
         *,
         name_key: str,
@@ -88,11 +92,22 @@ class V2CButton(V2CEntity, ButtonEntity):
         super().__init__(coordinator, client, device_id)
         self._coroutine_factory = coroutine_factory
         self._refresh_after_call = refresh_after_call
+        self._runtime_data = runtime_data
         self._attr_translation_key = name_key
         self._attr_unique_id = f"v2c_{device_id}_{unique_suffix}"
         self._attr_icon = icon
         if entity_category:
             self._attr_entity_category = entity_category
+
+    @property
+    def available(self) -> bool:
+        """Return True only while the action behind the button can be issued."""
+        # Reboot and firmware update are cloud commands with no LAN equivalent.
+        # A button that can be pressed but does nothing is a worse answer than
+        # one that is visibly out of service.
+        if not self._runtime_data.cloud_commands_available:
+            return False
+        return self.coordinator.last_update_success
 
     async def async_press(self) -> None:
         """Execute the button action."""

--- a/custom_components/v2c_cloud/entity.py
+++ b/custom_components/v2c_cloud/entity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -12,6 +13,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import DOMAIN
+from .v2c_cloud import V2CAuthError
 
 if TYPE_CHECKING:
     from .v2c_cloud import V2CClient
@@ -231,6 +233,16 @@ class V2CEntity(CoordinatorEntity[DataUpdateCoordinator]):
 
     async def _async_call_and_refresh(self, coro: Any, *, refresh: bool = True) -> None:
         """Helper to perform an API call and optionally refresh the cloud coordinator."""
-        await coro
+        try:
+            await coro
+        except V2CAuthError as err:
+            # The cloud reports a rejected key as an empty-bodied 401, so the
+            # raw exception surfaces as "V2C authentication failed: " followed
+            # by nothing — a traceback in the log and no explanation in the UI.
+            raise HomeAssistantError(
+                "The V2C Cloud rejected the API key, so this command was not "
+                "delivered to the charger. Controls served over the local "
+                "network keep working."
+            ) from err
         if refresh:
             await self.coordinator.async_request_refresh()

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.4.0-beta.4"
+  "version": "1.4.0-beta.5"
 }

--- a/custom_components/v2c_cloud/number.py
+++ b/custom_components/v2c_cloud/number.py
@@ -283,6 +283,12 @@ class V2CNumberEntity(_OptimisticHoldMixin, V2CEntity, NumberEntity):
     @property
     def available(self) -> bool:
         """Return True if the entity can be controlled."""
+        # Every number currently maps to a LAN keyword, so this guard is a
+        # standing rule rather than a live case: a value that can only travel
+        # over the cloud must not present itself as settable while the cloud
+        # is rejecting the key.
+        if self._local_key is None and not self._runtime_data.cloud_commands_available:
+            return False
         if self._local_coordinator is not None:
             return self._local_coordinator.last_update_success
         return self.coordinator.last_update_success

--- a/custom_components/v2c_cloud/select.py
+++ b/custom_components/v2c_cloud/select.py
@@ -230,6 +230,10 @@ class V2CEnumSelect(_OptimisticHoldMixin, V2CEntity, SelectEntity):
             and self._local_key in LAN_ONLY_KEYS
         ):
             return False
+        # Installation type, slave device and language have no LAN keyword:
+        # without a working cloud they cannot be read or written at all.
+        if self._local_key is None and not self._runtime_data.cloud_commands_available:
+            return False
         if self._local_coordinator is not None:
             return self._local_coordinator.last_update_success
         return self.coordinator.last_update_success

--- a/custom_components/v2c_cloud/switch.py
+++ b/custom_components/v2c_cloud/switch.py
@@ -303,6 +303,12 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
             key in LAN_ONLY_KEYS for key in self._local_keys
         ):
             return False
+        # The mirror case: a switch with no LAN keyword at all (OCPP, the RFID
+        # reader) can only be driven over the cloud. While the cloud rejects
+        # the key, offering it as operable invites a command that raises deep
+        # in the client and changes nothing on the charger.
+        if not self._local_keys and not self._runtime_data.cloud_commands_available:
+            return False
         if self._local_coordinator is not None:
             return self._local_coordinator.last_update_success
         return self.coordinator.last_update_success
@@ -342,8 +348,12 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
             self._apply_icon(self._optimistic_state)
             return self._optimistic_state
 
+        # No payload has ever carried this switch's key. "Off" would be an
+        # assertion the integration cannot make — and it read as one: an OCPP
+        # switch sat at "off" all through a cloud outage, looking like a
+        # setting that had been checked rather than one never received.
         self._apply_icon(state=False)
-        return False
+        return None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to the local coordinator once the entity is registered."""

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -30,12 +30,14 @@ def _make_coordinator(connected_value, reported_value=None):
     return coord
 
 
-def _make_sensor(connected_value=None, reported_value=None):
+def _make_sensor(connected_value=None, reported_value=None, cloud_ok=True):
     from custom_components.v2c_cloud.binary_sensor import V2CConnectedBinarySensor
 
     coord = _make_coordinator(connected_value, reported_value)
     client = MagicMock()
-    return V2CConnectedBinarySensor(coord, client, "dev-1")
+    runtime_data = MagicMock()
+    runtime_data.cloud_commands_available = cloud_ok
+    return V2CConnectedBinarySensor(coord, client, runtime_data, "dev-1")
 
 
 class TestV2CConnectedBinarySensor:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 
-def _make_button(*, coroutine_factory=None, refresh_after_call=True):
+def _make_button(*, coroutine_factory=None, refresh_after_call=True, cloud_ok=True):
     from custom_components.v2c_cloud.button import V2CButton
 
     coord = MagicMock()
@@ -18,12 +18,16 @@ def _make_button(*, coroutine_factory=None, refresh_after_call=True):
     client = MagicMock()
     client.async_reboot = AsyncMock(return_value=None)
 
+    runtime_data = MagicMock()
+    runtime_data.cloud_commands_available = cloud_ok
+
     if coroutine_factory is None:
         coroutine_factory = lambda: client.async_reboot("dev-1")  # noqa: E731
 
     button = V2CButton(
         coord,
         client,
+        runtime_data,
         "dev-1",
         name_key="reboot",
         unique_suffix="reboot",

--- a/tests/test_cloud_only_availability.py
+++ b/tests/test_cloud_only_availability.py
@@ -82,12 +82,21 @@ class TestSensorAvailabilityGating:
 class TestSwitchAvailabilityGating:
     """V2CBooleanSwitch.available — cloud_only + LAN-only local_keys → False."""
 
-    def _switch(self, *, local_keys: tuple[str, ...], cloud_only: bool) -> object:
+    def _switch(
+        self,
+        *,
+        local_keys: tuple[str, ...],
+        cloud_only: bool,
+        cloud_ok: bool = True,
+    ) -> object:
         from custom_components.v2c_cloud.switch import V2CBooleanSwitch
 
         sw = V2CBooleanSwitch.__new__(V2CBooleanSwitch)
         sw._runtime_data = MagicMock()
         sw._runtime_data.cloud_only = cloud_only
+        # Stated outright: a bare MagicMock is truthy, so leaving this to the
+        # mock would make the cloud-health gate untestable by accident.
+        sw._runtime_data.cloud_commands_available = cloud_ok
         sw._local_keys = local_keys
         sw._local_coordinator = None
         sw.coordinator = MagicMock()
@@ -120,12 +129,19 @@ class TestSwitchAvailabilityGating:
 class TestSelectAvailabilityGating:
     """V2CEnumSelect.available — cloud_only + LAN-only local_key → False."""
 
-    def _select(self, *, local_key: str | None, cloud_only: bool) -> object:
+    def _select(
+        self,
+        *,
+        local_key: str | None,
+        cloud_only: bool,
+        cloud_ok: bool = True,
+    ) -> object:
         from custom_components.v2c_cloud.select import V2CEnumSelect
 
         sel = V2CEnumSelect.__new__(V2CEnumSelect)
         sel._runtime_data = MagicMock()
         sel._runtime_data.cloud_only = cloud_only
+        sel._runtime_data.cloud_commands_available = cloud_ok
         sel._local_key = local_key
         sel._local_coordinator = None
         sel.coordinator = MagicMock()
@@ -142,10 +158,175 @@ class TestSelectAvailabilityGating:
 
     def test_cloud_only_no_local_key_available(self) -> None:
         # installation_type / language have no local_key → read directly from
-        # /reported, so they MUST stay available in cloud-only mode.
+        # /reported, so they MUST stay available in cloud-only mode — as long
+        # as the cloud itself is answering.
         sel = self._select(local_key=None, cloud_only=True)
         assert sel.available is True
 
     def test_local_mode_lan_select_available(self) -> None:
         sel = self._select(local_key="ChargeMode", cloud_only=False)
         assert sel.available is True
+
+
+# ---------------------------------------------------------------------------
+# The mirror case: the cloud is what is missing, not the LAN
+# ---------------------------------------------------------------------------
+
+
+class TestUnauthenticatedCloudGating:
+    """
+    A control with no LAN route must go Unavailable when the cloud is out.
+
+    During the V2C auth outage (issue #54) the integration kept running over
+    the LAN, which is the point — but OCPP and the RFID reader, which exist
+    only in the cloud API, stayed available and toggleable. Pressing one
+    raised deep inside the client and changed nothing on the charger, while
+    the switch went on displaying a state it had never received. The
+    integration's own log said "cloud-only controls are unavailable until it
+    recovers"; nothing in the code made that true.
+    """
+
+    def _switch(self, *, local_keys: tuple[str, ...], cloud_ok: bool) -> object:
+        from custom_components.v2c_cloud.switch import V2CBooleanSwitch
+
+        sw = V2CBooleanSwitch.__new__(V2CBooleanSwitch)
+        sw._runtime_data = MagicMock()
+        sw._runtime_data.cloud_only = False
+        sw._runtime_data.cloud_commands_available = cloud_ok
+        sw._local_keys = local_keys
+        sw._local_coordinator = None
+        sw.coordinator = MagicMock()
+        sw.coordinator.last_update_success = True
+        return sw
+
+    def _select(self, *, local_key: str | None, cloud_ok: bool) -> object:
+        from custom_components.v2c_cloud.select import V2CEnumSelect
+
+        sel = V2CEnumSelect.__new__(V2CEnumSelect)
+        sel._runtime_data = MagicMock()
+        sel._runtime_data.cloud_only = False
+        sel._runtime_data.cloud_commands_available = cloud_ok
+        sel._local_key = local_key
+        sel._local_coordinator = None
+        sel.coordinator = MagicMock()
+        sel.coordinator.last_update_success = True
+        return sel
+
+    def _number(self, *, local_key: str | None, cloud_ok: bool) -> object:
+        from custom_components.v2c_cloud.number import V2CNumberEntity
+
+        num = V2CNumberEntity.__new__(V2CNumberEntity)
+        num._runtime_data = MagicMock()
+        num._runtime_data.cloud_commands_available = cloud_ok
+        num._local_key = local_key
+        num._local_coordinator = None
+        num.coordinator = MagicMock()
+        num.coordinator.last_update_success = True
+        return num
+
+    def _button(self, *, cloud_ok: bool) -> object:
+        from custom_components.v2c_cloud.button import V2CButton
+
+        btn = V2CButton.__new__(V2CButton)
+        btn._runtime_data = MagicMock()
+        btn._runtime_data.cloud_commands_available = cloud_ok
+        btn.coordinator = MagicMock()
+        btn.coordinator.last_update_success = True
+        return btn
+
+    def _binary_sensor(self, *, cloud_ok: bool) -> object:
+        from custom_components.v2c_cloud.binary_sensor import V2CConnectedBinarySensor
+
+        sensor = V2CConnectedBinarySensor.__new__(V2CConnectedBinarySensor)
+        sensor._runtime_data = MagicMock()
+        sensor._runtime_data.cloud_commands_available = cloud_ok
+        sensor.coordinator = MagicMock()
+        sensor.coordinator.last_update_success = True
+        return sensor
+
+    # -- switches ----------------------------------------------------------
+
+    def test_ocpp_switch_unavailable_without_cloud(self) -> None:
+        """OCPP has no LAN keyword at all."""
+        assert self._switch(local_keys=(), cloud_ok=False).available is False
+
+    def test_ocpp_switch_available_with_cloud(self) -> None:
+        assert self._switch(local_keys=(), cloud_ok=True).available is True
+
+    def test_lan_backed_switch_survives_the_outage(self) -> None:
+        """The whole point of degrading instead of unloading."""
+        assert self._switch(local_keys=("Dynamic",), cloud_ok=False).available is True
+
+    # -- selects -----------------------------------------------------------
+
+    def test_cloud_only_select_unavailable_without_cloud(self) -> None:
+        """Installation type, slave device and language are cloud-only."""
+        assert self._select(local_key=None, cloud_ok=False).available is False
+
+    def test_lan_backed_select_survives_the_outage(self) -> None:
+        assert self._select(local_key="ChargeMode", cloud_ok=False).available is True
+
+    # -- numbers -----------------------------------------------------------
+
+    def test_cloud_only_number_unavailable_without_cloud(self) -> None:
+        assert self._number(local_key=None, cloud_ok=False).available is False
+
+    def test_lan_backed_number_survives_the_outage(self) -> None:
+        assert self._number(local_key="Intensity", cloud_ok=False).available is True
+
+    # -- buttons and the cloud connectivity sensor -------------------------
+
+    def test_buttons_unavailable_without_cloud(self) -> None:
+        """Reboot and firmware update are cloud commands with no LAN twin."""
+        assert self._button(cloud_ok=False).available is False
+
+    def test_buttons_available_with_cloud(self) -> None:
+        assert self._button(cloud_ok=True).available is True
+
+    def test_cloud_connectivity_sensor_unavailable_without_cloud(self) -> None:
+        """
+        It reports what the cloud thinks, so a dead cloud leaves it nothing.
+
+        Crucially it must not read as "the charger is offline": the LAN may be
+        working, and `Trasporto attivo` is the sensor that says so.
+        """
+        assert self._binary_sensor(cloud_ok=False).available is False
+
+    def test_cloud_connectivity_sensor_available_with_cloud(self) -> None:
+        assert self._binary_sensor(cloud_ok=True).available is True
+
+
+class TestCloudAuthState:
+    """`cloud_commands_available` is the single source of truth."""
+
+    def test_healthy_by_default(self) -> None:
+        from custom_components.v2c_cloud import _CloudAuthState
+
+        assert _CloudAuthState().usable is True
+
+    def test_degraded_blocks_cloud_commands(self) -> None:
+        from custom_components.v2c_cloud import _CloudAuthState
+
+        assert _CloudAuthState(degraded=True).usable is False
+
+    def test_lan_only_entry_has_no_cloud_at_all(self) -> None:
+        """No account was ever supplied, so cloud controls can never work."""
+        from custom_components.v2c_cloud import _CloudAuthState
+
+        assert _CloudAuthState(absent=True).usable is False
+
+    def test_runtime_data_exposes_the_state(self) -> None:
+        from custom_components.v2c_cloud import V2CEntryRuntimeData, _CloudAuthState
+
+        runtime = V2CEntryRuntimeData(
+            client=MagicMock(),
+            coordinator=MagicMock(),
+            cloud_auth=_CloudAuthState(degraded=True),
+        )
+        assert runtime.cloud_commands_available is False
+
+    def test_runtime_data_defaults_to_healthy(self) -> None:
+        from custom_components.v2c_cloud import V2CEntryRuntimeData
+
+        runtime = V2CEntryRuntimeData(client=MagicMock(), coordinator=MagicMock())
+        assert runtime.cloud_commands_available is True

--- a/tests/test_cloud_outage_resilience.py
+++ b/tests/test_cloud_outage_resilience.py
@@ -424,3 +424,53 @@ class TestEntryDataIsReadThroughMappingProxy:
         runtime.coordinator.data = None
         runtime.local_coordinators = {}
         assert resolve_static_ip(runtime, DEVICE_ID) == LAN_IP
+
+
+class TestRejectedKeyIsReportedNotSwallowed:
+    """
+    A command that cannot be delivered must say so, in words.
+
+    The cloud answers a rejected key with an empty-bodied 401, so the raw
+    exception reads "V2C authentication failed: " and nothing more. Pressing
+    the OCPP switch during the outage put that, plus a traceback, in the log
+    and left the UI with no explanation at all.
+    """
+
+    async def test_entity_command_raises_a_readable_error(self) -> None:
+        from homeassistant.exceptions import HomeAssistantError
+
+        from custom_components.v2c_cloud.entity import V2CEntity
+        from custom_components.v2c_cloud.v2c_cloud import V2CAuthError
+
+        entity = V2CEntity.__new__(V2CEntity)
+        entity.coordinator = MagicMock()
+
+        async def _rejected() -> None:
+            raise V2CAuthError("V2C authentication failed: ")
+
+        try:
+            await entity._async_call_and_refresh(_rejected())
+        except HomeAssistantError as err:
+            message = str(err)
+        else:
+            raise AssertionError("a rejected key must surface as an error")
+
+        assert "rejected the API key" in message
+        assert "local network" in message
+        # Never a bare refresh after a failed command.
+        entity.coordinator.async_request_refresh.assert_not_called()
+
+    async def test_successful_command_still_refreshes(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from custom_components.v2c_cloud.entity import V2CEntity
+
+        entity = V2CEntity.__new__(V2CEntity)
+        entity.coordinator = MagicMock()
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        async def _ok() -> None:
+            return None
+
+        await entity._async_call_and_refresh(_ok())
+        entity.coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -97,9 +97,16 @@ class TestV2CBooleanSwitchIsOn:
         switch, _ = _make_switch(local_keys=(), reported_value=False)
         assert switch.is_on is False
 
-    def test_returns_false_when_no_data_at_all(self):
+    def test_returns_unknown_when_no_data_at_all(self):
+        """
+        Never assert "off" for a switch whose state was never received.
+
+        A cloud-only switch with no payload used to report a confident `off`,
+        which read as a setting that had been checked rather than one that had
+        never arrived. `None` renders as Unknown, which is the truth.
+        """
         switch, _ = _make_switch(local_keys=(), reported_value=None)
-        assert switch.is_on is False
+        assert switch.is_on is None
 
     def test_optimistic_state_held_during_window(self):
         switch, _ = _make_switch(local_keys=())


### PR DESCRIPTION
## Problem

Degrading to the LAN instead of unloading kept the integration alive through the V2C authentication outage (#54) — but it left every control looking operable, including the ones with no LAN route at all.

Verified live on a Wi-Fi install while the cloud was rejecting the key:

| Entity | State | Reality |
|---|---|---|
| `switch.*_ocpp_abilitato` | `off`, toggleable | OCPP is cloud-only; the toggle raised inside the client |
| `switch.*_lettore_rfid` | `off`, toggleable | same |
| `select.*_tipo_di_installazione` | `unknown`, settable | cloud-only |
| `select.*_dispositivo_slave` | `unknown`, settable | cloud-only |
| `select.*_lingua` | `unknown`, settable | cloud-only |
| `button.*_riavvia_caricatore` | pressable | cloud-only |
| `button.*_aggiorna_firmware` | pressable | cloud-only |
| `binary_sensor.*_stato_connessione_v2c_cloud` | `unknown` | reports what the cloud thinks; the cloud is gone |

The log carried both halves of the contradiction — `V2C Cloud authentication failed (V2CAuthError); continuing over LAN. Cloud-only controls are unavailable until it recovers.` and, minutes later, a traceback from `async_turn_on` → `async_set_ocpp_enabled` → `V2CAuthError`.

Root cause: `available` derived from whichever coordinator the entity happened to have. A cloud-only control on a LAN-capable device inherited the *LAN* coordinator's health, and `coordinator.last_update_success` stays `True` in degraded mode by design.

## Change

Cloud health is tracked in one place (`_CloudAuthState`, already used for the repair issue) and exposed to the entity layer as `V2CEntryRuntimeData.cloud_commands_available` — false while the key is rejected, and false from the start on a LAN-only entry, which never had an account. Controls with no LAN keyword consult it; controls with one are untouched, which is the whole point of degrading rather than unloading.

Two related lies go with it:

- **A switch that has never received its state reports Unknown, not Off.** `is_on` fell through to a hardcoded `False`, which read as a setting that had been checked rather than one that never arrived.
- **A refused command surfaces a readable error.** The cloud answers a rejected key with an empty-bodied 401, so the raw exception read `V2C authentication failed: ` and nothing else. From a service call it also no longer raises `ConfigEntryAuthFailed` — that would open the reauth dialog this release deliberately removed elsewhere; whether a rejected key means "reauth" or "carry on over LAN" stays the coordinator's decision, taken in one place.

## Tests

599 passing. New `TestUnauthenticatedCloudGating` and `TestCloudAuthState` in `tests/test_cloud_only_availability.py`, plus `TestRejectedKeyIsReportedNotSwallowed` in `tests/test_cloud_outage_resilience.py`; 12 of them fail against the pre-change code (verified). The existing helpers now set the cloud flag explicitly — a bare `MagicMock` is truthy, which would have made the gate untestable by accident.

Releases as `1.4.0-beta.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
