### PR TITLE
fix: notice a rejected key on every refresh — 1.4.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0-beta.6] - 2026-09-11
+
+### Fixed
+
+- A V2C Cloud authentication failure is now detected on every refresh, so the
+  repair notice appears and cloud-only controls report as unavailable as soon
+  as the cloud stops accepting the API key — including in the hour after a
+  restart, when the pairings cache could previously mask the outage entirely.
+
 ## [1.4.0-beta.5] - 2026-09-11
 
 ### Changed

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.4.0-beta.5"
+  "version": "1.4.0-beta.6"
 }

--- a/custom_components/v2c_cloud/v2c_cloud.py
+++ b/custom_components/v2c_cloud/v2c_cloud.py
@@ -902,6 +902,17 @@ async def _fetch_single_device_state(  # noqa: C901
         if isinstance(outcome, V2CRateLimitError):
             raise outcome
 
+    # So must a rejected key. `return_exceptions=True` used to bury it here as a
+    # per-call warning, leaving the refresh to finish "successfully" with empty
+    # payloads — so the coordinator never learned the cloud was unauthenticated,
+    # never raised the repair issue, and left every cloud-only control offering
+    # itself as operable. `/device/reported` runs on every cycle, which makes it
+    # the signal that actually notices; `/pairings/me` is served from a one-hour
+    # cache and can stay quiet for an hour after a restart.
+    for outcome in gather_results:
+        if isinstance(outcome, V2CAuthError):
+            raise outcome
+
     # --- Process reported state ---
     reported: Any = result_map["reported"]
     if isinstance(reported, Exception):
@@ -1081,6 +1092,12 @@ async def async_gather_devices_state(
     for pairing, outcome in zip(valid_pairings, raw_results, strict=True):
         device_id = pairing["deviceId"]
         if isinstance(outcome, V2CRateLimitError):
+            raise outcome
+        # A rejected key is a property of the account, not of one charger, and
+        # the coordinator has to hear about it to decide between degrading to
+        # LAN and asking for a new key. Logging it as an "unexpected error" per
+        # device and carrying on hid a total cloud outage behind a warning.
+        if isinstance(outcome, V2CAuthError):
             raise outcome
         if isinstance(outcome, Exception):
             _LOGGER.warning(

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.v2c_cloud.v2c_cloud import (
+    V2CAuthError,
     V2CRateLimitError,
     V2CRequestError,
     async_gather_devices_state,
@@ -103,6 +104,40 @@ class TestAsyncGatherDevicesState:
         )
         assert "dev-A" in result
         assert "dev-B" in result
+
+    async def test_auth_error_propagates(self):
+        """
+        A rejected key must reach the coordinator, not stop at a warning.
+
+        `return_exceptions=True` buried it twice — once per API call, once per
+        device — so a refresh finished "successfully" with empty payloads. The
+        coordinator never learned the cloud was unauthenticated, so it never
+        raised the repair issue and never marked the cloud-only controls
+        unavailable, while `/device/reported` went on failing every cycle.
+        """
+        client = _make_client(reported_error=V2CAuthError("401"))
+        with pytest.raises(V2CAuthError):
+            await async_gather_devices_state(client, [{"deviceId": "dev-1"}])
+
+    async def test_auth_error_on_any_call_propagates(self):
+        """Any cloud call answering 401 means the same thing for the account."""
+        client = _make_client(current_state_charge_error=V2CAuthError("401"))
+        with pytest.raises(V2CAuthError):
+            await async_gather_devices_state(client, [{"deviceId": "dev-1"}])
+
+    async def test_auth_error_aborts_the_whole_cycle(self):
+        """
+        Authentication is a property of the account, not of one charger.
+
+        Returning the chargers that happened to answer would leave the entry
+        looking healthy on a partial payload.
+        """
+        client = _make_client(reported_error=V2CAuthError("401"))
+        with pytest.raises(V2CAuthError):
+            await async_gather_devices_state(
+                client,
+                [{"deviceId": "dev-A"}, {"deviceId": "dev-B"}],
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

beta.5 made cloud-only controls go unavailable when the cloud is unauthenticated. Verified live afterwards: they were still available.

The degraded-cloud machinery was in place and correct — almost nothing ever triggered it.

`asyncio.gather(return_exceptions=True)` buried `V2CAuthError` at two levels:

- **per API call** (`_fetch_single_device_state`): only `V2CRateLimitError` was re-raised; a 401 on `/device/reported` became `Failed to fetch reported state for XQUXDU: V2C authentication failed:` and `reported = None`.
- **per device** (`async_gather_devices_state`): same shape, logged as `Unexpected error fetching state for ...` and skipped.

So the refresh finished "successfully" with empty payloads. The only call that could actually raise was `/pairings/me` — and `async_get_pairings` serves from a one-hour cache that `preload_pairings` fills at startup from `cached_pairings`. After a restart the integration could therefore run a **full hour** without ever discovering the cloud had stopped accepting the key.

Evidence from a live instance during the #54 outage:

- `V2C Cloud authentication failed (V2CAuthError); continuing over LAN` — logged **once**, at 15:20, and never again across two restarts.
- `Failed to fetch reported state for XQUXDU: V2C authentication failed:` — every ~3.4 minutes, continuously.
- After the restart onto beta.5 at 17:00: OCPP, RFID, the cloud connectivity sensor and the reboot button all `unknown` rather than `unavailable`, i.e. `cloud_commands_available` still true.

## Change

A rejected key is a property of the account, not of one call or one charger, so it propagates like a rate limit does — at both gather levels. `/device/reported` runs on every refresh cycle, which makes it the signal that actually notices, rather than a cached endpoint that can stay quiet for an hour.

Downstream this reaches the existing, already-tested path: `_degraded_cloud_payload` → repair notice raised, previous data kept, LAN polling untouched, `cloud_commands_available` false.

## Tests

602 passing. Three new cases in `tests/test_gather.py`; all three fail against the pre-fix code (verified — and fail emitting the exact warning seen in the live logs).

Releases as `1.4.0-beta.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
