### PR TITLE
fix: address two Codex findings on #61 and #62 — 1.4.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0-beta.7] - 2026-09-11
+
+### Fixed
+
+- Clearing the manual IP checkbox now removes the stored addresses on a Cloud
+  only (4G) entry as well. Switching from Local (Wi-Fi) to Cloud only still
+  keeps them.
+- A command refused by the cloud makes the integration re-check the connection
+  straight away, instead of leaving cloud-only controls operable until the next
+  scheduled refresh.
+- A switch whose command fails returns to its previous state instead of
+  displaying the requested one for the rest of the optimistic hold window.
+
 ## [1.4.0-beta.6] - 2026-09-11
 
 ### Fixed

--- a/custom_components/v2c_cloud/config_flow.py
+++ b/custom_components/v2c_cloud/config_flow.py
@@ -553,7 +553,8 @@ class V2COptionsFlow(config_entries.OptionsFlow):
                 # the other way leaves stored overrides alone: they cost
                 # nothing while unused and are still there on the way back.
                 is_lan = not changes[CONF_CLOUD_ONLY]
-                wants_manual = is_lan and bool(user_input.get(CONF_SET_MANUAL_IPS))
+                set_manual = bool(user_input.get(CONF_SET_MANUAL_IPS))
+                wants_manual = is_lan and set_manual
 
                 if wants_manual and not device_ids:
                     errors[CONF_SET_MANUAL_IPS] = "no_known_devices"
@@ -568,10 +569,18 @@ class V2COptionsFlow(config_entries.OptionsFlow):
                     self._mode_changed = mode_changed
                     return await self.async_step_manual_ip()
                 else:
-                    if is_lan and current_manual:
-                        # The box now mirrors what is stored, so clearing it is
-                        # the gesture that drops every override and hands the
-                        # addresses back to cloud discovery.
+                    # The box now mirrors what is stored, so clearing it is the
+                    # gesture that drops every override and hands the addresses
+                    # back to cloud discovery — on a Cloud only (4G) entry too,
+                    # where the box is still shown and still says so.
+                    #
+                    # The single exception is the move TO Cloud only: there the
+                    # box is about to become irrelevant, and a user tidying it
+                    # up on the way out must not silently lose the addresses
+                    # they will need the moment they come back to Wi-Fi — which
+                    # is exactly when the cloud may be unable to supply them.
+                    switching_to_cloud = mode_changed and not is_lan
+                    if current_manual and not set_manual and not switching_to_cloud:
                         changes[CONF_MANUAL_IPS] = {}
                     return self._apply(changes, new_options, mode_changed=mode_changed)
 

--- a/custom_components/v2c_cloud/entity.py
+++ b/custom_components/v2c_cloud/entity.py
@@ -236,6 +236,13 @@ class V2CEntity(CoordinatorEntity[DataUpdateCoordinator]):
         try:
             await coro
         except V2CAuthError as err:
+            # This call just proved the cloud is unauthenticated, so the shared
+            # state must not wait for the next scheduled poll to rediscover it.
+            # The proof is handed to the coordinator rather than acted on here:
+            # whether a rejected key means "degrade to LAN" or "ask for a new
+            # key" depends on the entry, and that decision already lives in one
+            # place.
+            await self.coordinator.async_request_refresh()
             # The cloud reports a rejected key as an empty-bodied 401, so the
             # raw exception surfaces as "V2C authentication failed: " followed
             # by nothing — a traceback in the log and no explanation in the UI.

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.4.0-beta.6"
+  "version": "1.4.0-beta.7"
 }

--- a/custom_components/v2c_cloud/switch.py
+++ b/custom_components/v2c_cloud/switch.py
@@ -378,13 +378,24 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
         await self._async_call(state=False)
 
     async def _async_call(self, state: bool) -> None:
+        previous_state = self._optimistic_state
         self._optimistic_state = state
         self._record_command()
         self.async_write_ha_state()
-        await self._async_call_and_refresh(
-            self._setter(state),
-            refresh=self._refresh_after_call,
-        )
+        try:
+            await self._async_call_and_refresh(
+                self._setter(state),
+                refresh=self._refresh_after_call,
+            )
+        except Exception:
+            # The requested state was displayed on the assumption the command
+            # would land. It did not, so the assumption has to go with it —
+            # otherwise the switch shows what was asked for, for the whole hold
+            # window (90 s on the cloud-only ones), as if it had worked.
+            self._optimistic_state = previous_state
+            self._clear_command()
+            self.async_write_ha_state()
+            raise
         if self._trigger_local_refresh:
             await async_request_local_refresh(self._runtime_data, self._device_id)
         self._schedule_delayed_refresh()

--- a/tests/test_cloud_outage_resilience.py
+++ b/tests/test_cloud_outage_resilience.py
@@ -21,6 +21,7 @@ from types import MappingProxyType
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.v2c_cloud import (
@@ -437,6 +438,8 @@ class TestRejectedKeyIsReportedNotSwallowed:
     """
 
     async def test_entity_command_raises_a_readable_error(self) -> None:
+        from unittest.mock import AsyncMock
+
         from homeassistant.exceptions import HomeAssistantError
 
         from custom_components.v2c_cloud.entity import V2CEntity
@@ -444,6 +447,7 @@ class TestRejectedKeyIsReportedNotSwallowed:
 
         entity = V2CEntity.__new__(V2CEntity)
         entity.coordinator = MagicMock()
+        entity.coordinator.async_request_refresh = AsyncMock()
 
         async def _rejected() -> None:
             raise V2CAuthError("V2C authentication failed: ")
@@ -457,8 +461,35 @@ class TestRejectedKeyIsReportedNotSwallowed:
 
         assert "rejected the API key" in message
         assert "local network" in message
-        # Never a bare refresh after a failed command.
-        entity.coordinator.async_request_refresh.assert_not_called()
+
+    async def test_failed_command_tells_the_coordinator(self) -> None:
+        """
+        The command proved the cloud is unauthenticated — don't wait for a poll.
+
+        Without this, the cloud-only controls stayed available until the next
+        scheduled refresh independently rediscovered what the command had
+        already established. The coordinator is asked to refresh rather than
+        being told what to conclude: degrade-to-LAN versus ask-for-a-new-key
+        depends on the entry, and that decision lives in one place.
+        """
+        from unittest.mock import AsyncMock
+
+        from homeassistant.exceptions import HomeAssistantError
+
+        from custom_components.v2c_cloud.entity import V2CEntity
+        from custom_components.v2c_cloud.v2c_cloud import V2CAuthError
+
+        entity = V2CEntity.__new__(V2CEntity)
+        entity.coordinator = MagicMock()
+        entity.coordinator.async_request_refresh = AsyncMock()
+
+        async def _rejected() -> None:
+            raise V2CAuthError("401")
+
+        with pytest.raises(HomeAssistantError):
+            await entity._async_call_and_refresh(_rejected())
+
+        entity.coordinator.async_request_refresh.assert_awaited_once()
 
     async def test_successful_command_still_refreshes(self) -> None:
         from unittest.mock import AsyncMock

--- a/tests/test_lan_only_setup.py
+++ b/tests/test_lan_only_setup.py
@@ -509,6 +509,54 @@ class TestManualIpSteps:
         written = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
         assert written[CONF_MANUAL_IPS] == {DEVICE_ID: LAN_IP}
 
+    async def test_clearing_the_box_works_on_a_cloud_only_entry_too(self):
+        """
+        The box is shown on 4G entries and says it removes the addresses.
+
+        Gating the clear on the destination being LAN made that promise a
+        no-op for an entry that was already Cloud only: the only way to drop
+        an address was to detour through Local (Wi-Fi) and back.
+        """
+        entry = _entry(
+            **{
+                CONF_CLOUD_ONLY: True,
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LAN_IP}],
+                CONF_MANUAL_IPS: {DEVICE_ID: LAN_IP},
+            }
+        )
+        flow = self._flow(entry)
+        await flow.async_step_init(
+            {
+                "connection_type": "cloud_only",
+                CONF_LOCAL_UPDATE_INTERVAL: 30,
+                CONF_SET_MANUAL_IPS: False,
+            }
+        )
+
+        written = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert written[CONF_MANUAL_IPS] == {}
+
+    async def test_leaving_the_box_alone_on_a_cloud_only_entry_keeps_them(self):
+        flow = self._flow(
+            _entry(
+                **{
+                    CONF_CLOUD_ONLY: True,
+                    CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LAN_IP}],
+                    CONF_MANUAL_IPS: {DEVICE_ID: LAN_IP},
+                }
+            )
+        )
+        await flow.async_step_init(
+            {
+                "connection_type": "cloud_only",
+                CONF_LOCAL_UPDATE_INTERVAL: 30,
+                CONF_SET_MANUAL_IPS: True,
+            }
+        )
+
+        written = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert written[CONF_MANUAL_IPS] == {DEVICE_ID: LAN_IP}
+
     async def test_opting_in_with_no_known_charger_reports_an_error(self):
         """Silently saving nothing would look like the box never stuck."""
         flow = self._flow(_entry(**{CONF_CLOUD_ONLY: False}))

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 
 def _make_switch(
     *,
@@ -178,3 +180,72 @@ class TestV2CBooleanSwitchAvailability:
         switch._local_coordinator = None
         switch.coordinator.last_update_success = True
         assert switch.available is True
+
+
+class TestFailedCommandDoesNotStick:
+    """
+    A command that was refused must not leave its requested state on display.
+
+    The switch writes the requested state optimistically before calling the
+    API, so the UI reacts instantly. When the call fails that assumption is
+    wrong, and holding it made a refused OCPP toggle read as "on" for the full
+    90-second hold window.
+    """
+
+    def _switch_with_failing_setter(self, error):
+        from custom_components.v2c_cloud.switch import V2CBooleanSwitch
+
+        switch, _ = _make_switch(local_keys=())
+        switch._setter = AsyncMock(side_effect=error)
+        switch.async_write_ha_state = MagicMock()
+        switch.coordinator = MagicMock()
+        switch.coordinator.async_request_refresh = AsyncMock()
+        assert isinstance(switch, V2CBooleanSwitch)
+        return switch
+
+    async def test_optimistic_state_is_rolled_back_on_auth_failure(self):
+        from homeassistant.exceptions import HomeAssistantError
+
+        from custom_components.v2c_cloud.v2c_cloud import V2CAuthError
+
+        switch = self._switch_with_failing_setter(V2CAuthError("401"))
+
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+
+        assert switch._optimistic_state is None
+        assert switch._last_command_ts is None
+
+    async def test_optimistic_state_is_rolled_back_on_any_failure(self):
+        from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
+
+        switch = self._switch_with_failing_setter(V2CRequestError("500", status=500))
+
+        with pytest.raises(V2CRequestError):
+            await switch.async_turn_on()
+
+        assert switch._optimistic_state is None
+
+    async def test_previous_state_is_restored_not_just_cleared(self):
+        """A switch that was legitimately on stays on when turning it off fails."""
+        from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
+
+        switch = self._switch_with_failing_setter(V2CRequestError("500", status=500))
+        switch._optimistic_state = True
+
+        with pytest.raises(V2CRequestError):
+            await switch.async_turn_off()
+
+        assert switch._optimistic_state is True
+
+    async def test_successful_command_keeps_the_optimistic_state(self):
+        switch, setter = _make_switch(local_keys=())
+        switch.async_write_ha_state = MagicMock()
+        switch.coordinator = MagicMock()
+        switch.coordinator.async_request_refresh = AsyncMock()
+        switch._schedule_delayed_refresh = MagicMock()
+
+        await switch.async_turn_on()
+
+        setter.assert_awaited_once()
+        assert switch._optimistic_state is True


### PR DESCRIPTION
Addresses the two Codex findings that landed on #61 and #62 just after each was merged.

## 1. Clearing manual IPs was a no-op on a Cloud only entry (#61, P2)

The clear was gated on the *destination* mode being LAN. On an entry that was already Cloud only, the box rendered ticked (addresses exist), could be unticked, and nothing happened — `_apply` preserved every override. The form's own text, "clear it to remove every manual address", was only true if the user detoured through Local (Wi-Fi) and back.

The intent behind the gate was worth keeping, but it was too wide: what must not destroy addresses is the **transition** to Cloud only, where the box is about to become irrelevant and a user tidying it up on the way out would silently lose the addresses they need the moment they return to Wi-Fi — exactly when the cloud may be unable to supply them.

So the clear now applies wherever the user performs it, with that one exception:

| Current | Destination | Box | Result |
|---|---|---|---|
| Local | Local | unticked | cleared |
| Cloud only | Cloud only | unticked | **cleared** (was: kept) |
| Cloud only | Local | unticked | cleared |
| Local | Cloud only | unticked | kept |

## 2. A refused command didn't update the shared cloud-auth state (#62, P2)

A cloud-only command receiving a 401 raised a readable error and stopped there. The shared state stayed healthy, so OCPP/RFID and the rest remained available until a scheduled refresh independently rediscovered what the command had already proven.

The failure now asks the coordinator to refresh. It is handed the *proof*, not the *conclusion*: whether a rejected key means "degrade to LAN" or "ask for a new key" depends on the entry, and that decision already lives in one place (`_degraded_cloud_payload`). Setting the flag from the entity would have put a second copy of that judgement in the entity layer.

Codex also noted the switch keeps its optimistic state. It did: the requested state is written before the call so the UI reacts instantly, and on failure that assumption was never withdrawn — a refused OCPP toggle read as "on" for the full 90-second hold. The switch now rolls back to what it showed before, clears the hold, and re-renders.

## Tests

609 passing. Two new cases in `tests/test_lan_only_setup.py`, four in `tests/test_switch.py`, one in `tests/test_cloud_outage_resilience.py`; five of them fail against the pre-fix code (verified). One existing assertion was inverted on purpose — it asserted no refresh after a failed command, which is precisely what finding 2 says is wrong.

Releases as `1.4.0-beta.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
