### PR TITLE
fix: don't let a failed command trample a newer one — 1.4.0-beta.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0-beta.8] - 2026-09-11
+
+### Fixed
+
+- When two commands for the same switch overlap, a failure of the earlier one
+  no longer discards the state and hold window established by the later one.
+
 ## [1.4.0-beta.7] - 2026-09-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- When two commands for the same switch overlap, a failure of the earlier one
-  no longer discards the state and hold window established by the later one.
+- A switch whose command fails no longer keeps a state that was never
+  confirmed: it falls back to the value the charger reports, or to Unknown when
+  there is none. Overlapping commands are handled individually, so a failure no
+  longer discards the state established by a later command, nor leaves behind a
+  state that neither command achieved.
 
 ## [1.4.0-beta.7] - 2026-09-11
 

--- a/custom_components/v2c_cloud/entity.py
+++ b/custom_components/v2c_cloud/entity.py
@@ -141,10 +141,26 @@ class _OptimisticHoldMixin:
 
     _OPTIMISTIC_HOLD_SECONDS: float = 20.0
     _last_command_ts: float | None  # initialised by subclass
+    _command_seq: int = 0
 
-    def _record_command(self) -> None:
-        """Mark that a command was issued; starts the optimistic hold window."""
+    def _record_command(self) -> int:
+        """
+        Mark that a command was issued; starts the optimistic hold window.
+
+        Returns a token identifying this command. Two service calls can be in
+        flight on the same entity at once — two automations firing together,
+        say — and the second one owns the display from the moment it starts.
+        An invocation that wants to undo its own bookkeeping later must check
+        the token first with ``_is_latest_command``, or it will trample a
+        newer command that is still pending.
+        """
         self._last_command_ts = time.monotonic()
+        self._command_seq += 1
+        return self._command_seq
+
+    def _is_latest_command(self, token: int) -> bool:
+        """Return True when no further command has been issued since ``token``."""
+        return self._command_seq == token
 
     def _clear_command(self) -> None:
         """Clear the hold so the entity reads real state on next coordinator update."""

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.4.0-beta.7"
+  "version": "1.4.0-beta.8"
 }

--- a/custom_components/v2c_cloud/switch.py
+++ b/custom_components/v2c_cloud/switch.py
@@ -378,7 +378,6 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
         await self._async_call(state=False)
 
     async def _async_call(self, state: bool) -> None:
-        previous_state = self._optimistic_state
         self._optimistic_state = state
         token = self._record_command()
         self.async_write_ha_state()
@@ -393,13 +392,20 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
             # otherwise the switch shows what was asked for, for the whole hold
             # window (90 s on the cloud-only ones), as if it had worked.
             #
-            # Only if this is still the latest command, though: a newer call
+            # Dropped rather than rolled back to the previous value: what was
+            # there before may itself have been another command's unconfirmed
+            # guess, and restoring it would let two refused commands leave a
+            # state on screen that neither of them ever achieved. With nothing
+            # held, `is_on` re-reads the payload — the real value if there is
+            # one, Unknown if there is not, which is the honest answer when no
+            # command was ever delivered.
+            #
+            # Only while this is still the latest command, though: a newer call
             # that started while this one was on the wire owns the display now,
-            # and restoring a state captured before it began — or clearing the
-            # hold it started — would leave the UI stale even when the newer
-            # command succeeds.
+            # and clearing its state or its hold would leave the UI stale even
+            # when that newer command succeeds.
             if self._is_latest_command(token):
-                self._optimistic_state = previous_state
+                self._optimistic_state = None
                 self._clear_command()
                 self.async_write_ha_state()
             raise

--- a/custom_components/v2c_cloud/switch.py
+++ b/custom_components/v2c_cloud/switch.py
@@ -380,7 +380,7 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
     async def _async_call(self, state: bool) -> None:
         previous_state = self._optimistic_state
         self._optimistic_state = state
-        self._record_command()
+        token = self._record_command()
         self.async_write_ha_state()
         try:
             await self._async_call_and_refresh(
@@ -392,9 +392,16 @@ class V2CBooleanSwitch(_OptimisticHoldMixin, V2CEntity, SwitchEntity):
             # would land. It did not, so the assumption has to go with it —
             # otherwise the switch shows what was asked for, for the whole hold
             # window (90 s on the cloud-only ones), as if it had worked.
-            self._optimistic_state = previous_state
-            self._clear_command()
-            self.async_write_ha_state()
+            #
+            # Only if this is still the latest command, though: a newer call
+            # that started while this one was on the wire owns the display now,
+            # and restoring a state captured before it began — or clearing the
+            # hold it started — would leave the UI stale even when the newer
+            # command succeeds.
+            if self._is_latest_command(token):
+                self._optimistic_state = previous_state
+                self._clear_command()
+                self.async_write_ha_state()
             raise
         if self._trigger_local_refresh:
             await async_request_local_refresh(self._runtime_data, self._device_id)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -227,17 +227,32 @@ class TestFailedCommandDoesNotStick:
 
         assert switch._optimistic_state is None
 
-    async def test_previous_state_is_restored_not_just_cleared(self):
-        """A switch that was legitimately on stays on when turning it off fails."""
+    async def test_confirmed_state_reappears_after_a_failed_command(self):
+        """A switch that really is on stays on when turning it off fails."""
         from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
 
-        switch = self._switch_with_failing_setter(V2CRequestError("500", status=500))
-        switch._optimistic_state = True
+        switch, _ = _make_switch(local_keys=("Dynamic",), local_value=1)
+        switch._setter = AsyncMock(side_effect=V2CRequestError("500", status=500))
+        switch.async_write_ha_state = MagicMock()
+        switch.coordinator = MagicMock()
+        switch.coordinator.async_request_refresh = AsyncMock()
 
         with pytest.raises(V2CRequestError):
             await switch.async_turn_off()
 
-        assert switch._optimistic_state is True
+        # The requested "off" is gone and the payload speaks for itself again.
+        assert switch.is_on is True
+
+    async def test_nothing_is_invented_when_there_is_no_real_state(self):
+        """With no payload to fall back on, Unknown is the honest answer."""
+        from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
+
+        switch = self._switch_with_failing_setter(V2CRequestError("500", status=500))
+
+        with pytest.raises(V2CRequestError):
+            await switch.async_turn_on()
+
+        assert switch.is_on is None
 
     async def test_successful_command_keeps_the_optimistic_state(self):
         switch, setter = _make_switch(local_keys=())
@@ -308,14 +323,49 @@ class TestOverlappingCommands:
         from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
 
         switch = self._switch()
-        switch._optimistic_state = True
         switch._setter = AsyncMock(side_effect=V2CRequestError("500", status=500))
 
         with pytest.raises(V2CRequestError):
             await switch.async_turn_off()
 
-        assert switch._optimistic_state is True
+        assert switch._optimistic_state is None
         assert switch._last_command_ts is None
+
+    async def test_two_failed_commands_leave_nothing_behind(self):
+        """
+        Neither command landed, so neither may leave a state on screen.
+
+        Rolling back to the value held before the command restored the *other*
+        command's unconfirmed guess: an `on` that failed and an `off` that
+        failed could between them display `on`, a state the charger was never
+        put into and no call ever achieved.
+        """
+        from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
+
+        switch = self._switch()
+
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def _slow_then_fail(_state):
+            first_started.set()
+            await release_first.wait()
+            raise V2CRequestError("500", status=500)
+
+        switch._setter = AsyncMock(side_effect=_slow_then_fail)
+        first = asyncio.create_task(switch.async_turn_on())
+        await first_started.wait()
+
+        switch._setter = AsyncMock(side_effect=V2CRequestError("500", status=500))
+        with pytest.raises(V2CRequestError):
+            await switch.async_turn_off()
+
+        release_first.set()
+        with pytest.raises(V2CRequestError):
+            await first
+
+        assert switch._optimistic_state is None
+        assert switch.is_on is None
 
     async def test_each_command_gets_its_own_token(self):
         switch = self._switch()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -249,3 +250,78 @@ class TestFailedCommandDoesNotStick:
 
         setter.assert_awaited_once()
         assert switch._optimistic_state is True
+
+
+class TestOverlappingCommands:
+    """
+    A failing command must not trample a newer one that is still in flight.
+
+    Two service calls can overlap on the same entity — two automations firing
+    together, or a user tapping while a slow request is on the wire. The
+    second call owns the display from the moment it starts. Rolling back the
+    first one on failure restored a state captured before the second began and
+    cleared the hold the second had started, so the UI reverted to stale state
+    even when the newer command succeeded.
+    """
+
+    def _switch(self):
+        switch, _ = _make_switch(local_keys=())
+        switch.async_write_ha_state = MagicMock()
+        switch.coordinator = MagicMock()
+        switch.coordinator.async_request_refresh = AsyncMock()
+        switch._schedule_delayed_refresh = MagicMock()
+        return switch
+
+    async def test_older_failure_leaves_the_newer_command_alone(self):
+        from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
+
+        switch = self._switch()
+
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+
+        async def _slow_then_fail(_state):
+            first_started.set()
+            await release_first.wait()
+            raise V2CRequestError("500", status=500)
+
+        switch._setter = AsyncMock(side_effect=_slow_then_fail)
+        first = asyncio.create_task(switch.async_turn_on())
+        await first_started.wait()
+
+        # A second command starts and takes over the display.
+        switch._setter = AsyncMock(return_value=None)
+        await switch.async_turn_off()
+        assert switch._optimistic_state is False
+        hold_after_second = switch._last_command_ts
+
+        # Now let the first one fail.
+        release_first.set()
+        with pytest.raises(V2CRequestError):
+            await first
+
+        assert switch._optimistic_state is False, "newer command was overwritten"
+        assert switch._last_command_ts == hold_after_second, "newer hold was cleared"
+
+    async def test_latest_failure_still_rolls_back(self):
+        """The guard must not disable the rollback in the ordinary case."""
+        from custom_components.v2c_cloud.v2c_cloud import V2CRequestError
+
+        switch = self._switch()
+        switch._optimistic_state = True
+        switch._setter = AsyncMock(side_effect=V2CRequestError("500", status=500))
+
+        with pytest.raises(V2CRequestError):
+            await switch.async_turn_off()
+
+        assert switch._optimistic_state is True
+        assert switch._last_command_ts is None
+
+    async def test_each_command_gets_its_own_token(self):
+        switch = self._switch()
+        first = switch._record_command()
+        second = switch._record_command()
+
+        assert first != second
+        assert switch._is_latest_command(second) is True
+        assert switch._is_latest_command(first) is False


### PR DESCRIPTION
Addresses the Codex finding on #64.

## Problem

The rollback added in beta.7 assumed the command undoing itself was the only one in flight. It isn't necessarily: two service calls can overlap on the same entity — two automations firing together, or a tap while a slow request is on the wire — and the second one owns the display from the moment it starts.

Sequence:

1. Call A stores `previous_state`, writes its optimistic state, records a hold.
2. Call B starts, stores A's optimistic state as *its* `previous_state`, writes its own, records a new hold.
3. A fails → restores the state captured before B existed, and clears **B's** hold timestamp.
4. B succeeds → but the display already reverted, with no optimistic hold left to protect it.

The 90-second hold on the cloud-only switches makes the window wide enough to matter.

## Change

`_record_command()` now returns a token, and an invocation only undoes its own bookkeeping while `_is_latest_command(token)` holds. A newer command in flight means the older failure leaves the display alone — it is no longer the owner.

The counter lives in `_OptimisticHoldMixin` alongside the rest of the command bookkeeping; `number` and `select` call `_record_command()` for its side effect and are unaffected.

## Tests

612 passing. Three new cases in `tests/test_switch.py`, including one that runs the two calls genuinely concurrently and asserts the newer state and hold both survive. Two fail against the pre-fix code (verified) — the concurrency one fails on exactly the cleared-hold assertion.

Releases as `1.4.0-beta.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
