### PR TITLE
docs: describe resilience features generically, drop incident references

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 This custom integration links Home Assistant with the **V2C Cloud** platform. It combines the public cloud API with the wallbox local HTTP interface so that real-time data and frequent controls use the LAN endpoint while configuration tasks still rely on the official cloud endpoints. It is purpose-built for the official V2C Cloud APIs and the local APIs exposed by **V2C Trydan** chargers.
 
-> ⚠️ **V2C Cloud API outage (Sept 2026).** V2C's own authentication backend has been intermittently rejecting valid API keys — see [issue #54](https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues/54). It is not something the integration can fix on its own, but as of **1.4.0** a **Local (Wi-Fi)** setup keeps working over the LAN through an outage like this instead of going offline with it — see [Running without the cloud](#running-without-the-cloud) below.
-
 ### Companion Octopus Energy integration
 
 If you manage smart-charging slots through Intelligent Octopus, pair this project with my [Octopus Energy Italy integration](https://github.com/samuelebistoletti/HomeAssistant-OctopusEnergyIT). It exposes the Octopus APIs inside Home Assistant so that Intelligent Octopus can coordinate with V2C for advanced charging automations.
@@ -86,7 +84,7 @@ Changes are applied to all per-device local coordinators immediately; no integra
 
 ## Running without the cloud *(new in 1.4.0)*
 
-The V2C Cloud is not always available — see the [outage notice](#v2c-cloud-integration-for-home-assistant) at the top of this file for a current example. As of 1.4.0, a **Local (Wi-Fi)** setup is decoupled from that: the wallbox's own HTTP API is enough to keep telemetry and the controls it supports working, cloud or no cloud.
+The V2C Cloud is not always reachable — rate limits, connectivity issues, or an authentication rejection can all happen. As of 1.4.0, a **Local (Wi-Fi)** setup is decoupled from that: the wallbox's own HTTP API is enough to keep telemetry and the controls it supports working, cloud or no cloud.
 
 ### Set up without a V2C account
 1. **Settings → Devices & Services → Add Integration → V2C Cloud → Local only.**

--- a/custom_components/v2c_cloud/README.md
+++ b/custom_components/v2c_cloud/README.md
@@ -10,8 +10,6 @@
 
 This custom integration links Home Assistant with the **V2C Cloud** platform. It combines the public cloud API with the wallbox local HTTP interface so that real-time data and frequent controls use the LAN endpoint while configuration tasks still rely on the official cloud endpoints. It is purpose-built for the official V2C Cloud APIs and the local APIs exposed by **V2C Trydan** chargers.
 
-> ⚠️ **V2C Cloud API outage (Sept 2026).** V2C's own authentication backend has been intermittently rejecting valid API keys — see [issue #54](https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues/54). It is not something the integration can fix on its own, but as of **1.4.0** a **Local (Wi-Fi)** setup keeps working over the LAN through an outage like this instead of going offline with it — see [Running without the cloud](#running-without-the-cloud) below.
-
 ### Companion Octopus Energy integration
 
 If you manage smart-charging slots through Intelligent Octopus, pair this project with my [Octopus Energy Italy integration](https://github.com/samuelebistoletti/HomeAssistant-OctopusEnergyIT). It exposes the Octopus APIs inside Home Assistant so that Intelligent Octopus can coordinate with V2C for advanced charging automations.
@@ -86,7 +84,7 @@ Changes are applied to all per-device local coordinators immediately; no integra
 
 ## Running without the cloud *(new in 1.4.0)*
 
-The V2C Cloud is not always available — see the [outage notice](#v2c-cloud-integration-for-home-assistant) at the top of this file for a current example. As of 1.4.0, a **Local (Wi-Fi)** setup is decoupled from that: the wallbox's own HTTP API is enough to keep telemetry and the controls it supports working, cloud or no cloud.
+The V2C Cloud is not always reachable — rate limits, connectivity issues, or an authentication rejection can all happen. As of 1.4.0, a **Local (Wi-Fi)** setup is decoupled from that: the wallbox's own HTTP API is enough to keep telemetry and the controls it supports working, cloud or no cloud.
 
 ### Set up without a V2C account
 1. **Settings → Devices & Services → Add Integration → V2C Cloud → Local only.**

--- a/custom_components/v2c_cloud/__init__.py
+++ b/custom_components/v2c_cloud/__init__.py
@@ -290,9 +290,9 @@ def _degraded_cloud_payload(
     """
     Return degraded coordinator data, or None when the entry must reauth.
 
-    The V2C Cloud can reject a perfectly valid API key for days at a time
-    (issue #54). On a LAN-capable entry that must not unload the integration:
-    the charger is still reachable over HTTP. A repair issue is raised, the
+    The V2C Cloud can reject a perfectly valid API key for extended periods.
+    On a LAN-capable entry that must not unload the integration: the charger
+    is still reachable over HTTP. A repair issue is raised, the
     previous data is kept, and polling carries on. A cloud-only entry has no
     alternative transport, so None is returned and the caller raises
     ConfigEntryAuthFailed exactly as before.
@@ -482,9 +482,9 @@ class V2CEntryRuntimeData:
 
         Some settings have no LAN equivalent at all — OCPP, the RFID reader,
         the installation and slave types, the language, reboot and firmware
-        update. When the cloud rejects the API key (issue #54) or the entry
-        has no account in the first place, those controls cannot do anything,
-        and an entity that still offers itself as operable is worse than an
+        update. When the cloud rejects the API key or the entry has no
+        account in the first place, those controls cannot do anything, and
+        an entity that still offers itself as operable is worse than an
         absent one: it invites a command that will be silently dropped.
         """
         return self.cloud_auth.usable
@@ -517,8 +517,8 @@ async def _async_fetch_initial_pairings(
         # A cloud-only charger has no other transport: the entry genuinely
         # cannot work, so ask for a new key. A LAN entry with a known address
         # keeps running over HTTP and only raises a repair issue — tearing it
-        # down here is what made a V2C-side auth outage look like a total
-        # integration failure on Wi-Fi installs (issue #54).
+        # down here would make a cloud-side auth failure look like a total
+        # integration failure on Wi-Fi installs.
         if not _may_degrade_to_lan(entry):
             raise ConfigEntryAuthFailed("Invalid V2C Cloud API key") from err
         _LOGGER.warning(
@@ -856,9 +856,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # `DataUpdateCoordinator.async_shutdown` is a COROUTINE function: it
             # must be awaited or nothing is cancelled at all and Python emits
             # "RuntimeWarning: coroutine 'DataUpdateCoordinator.async_shutdown'
-            # was never awaited" (reported from a user log in issue #54). The
-            # isawaitable guard keeps stub/mock coordinators that expose a plain
-            # synchronous attribute working.
+            # was never awaited". The isawaitable guard keeps stub/mock
+            # coordinators that expose a plain synchronous attribute working.
             for coord in runtime_data.local_coordinators.values():
                 shutdown = getattr(coord, "async_shutdown", None)
                 if shutdown is not None:

--- a/custom_components/v2c_cloud/config_flow.py
+++ b/custom_components/v2c_cloud/config_flow.py
@@ -150,9 +150,9 @@ class V2CConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Ask whether to set the integration up with or without a V2C account.
 
         The LAN-only branch exists because the cloud is not always available:
-        during the 2026-09 V2C authentication outage a fresh install was
-        impossible even for chargers sitting on the same network as Home
-        Assistant (issue #54).
+        without it, a fresh install is impossible even for a charger sitting on
+        the same network as Home Assistant, whenever the cloud is unreachable
+        or rejects authentication.
         """
         return self.async_show_menu(step_id="user", menu_options=["cloud", "lan_only"])
 

--- a/custom_components/v2c_cloud/local_api.py
+++ b/custom_components/v2c_cloud/local_api.py
@@ -495,10 +495,10 @@ def _ip_in_records(records: object, device_id: str) -> str | None:
 # Address sources in priority order. The user's explicit override wins, then
 # live cloud data, then the persisted cache, then whatever the charger last
 # told us about itself. Steps 1 and 3 are what keep the LAN transport alive
-# during a total cloud outage: before they existed every source was derived
-# from live cloud data, so an authentication failure left the integration with
-# no address at all and silently degraded a LAN install to cloud-only
-# behaviour (issue #54).
+# during a total cloud outage: without them every source would be derived
+# from live cloud data, so an authentication failure would leave the
+# integration with no address at all and silently degrade a LAN install to
+# cloud-only behaviour.
 _IP_SOURCES: tuple[Callable[[V2CEntryRuntimeData, str], str | None], ...] = (
     _ip_from_manual_override,
     _ip_from_cloud_runtime,
@@ -762,9 +762,8 @@ async def async_route_local_or_cloud(  # noqa: PLR0913
 
     if cloud_call is None:
         # Be precise about WHICH of the two conditions failed. Saying
-        # "cloud-only mode" on a Wi-Fi entry whose LAN write just failed sent
-        # users looking for a configuration problem that did not exist
-        # (issue #54).
+        # "cloud-only mode" on a Wi-Fi entry whose LAN write just failed sends
+        # users looking for a configuration problem that does not exist.
         if cloud_only:
             detail = (
                 "this entry is configured as Cloud only (4G), and the V2C "

--- a/custom_components/v2c_cloud/sensor.py
+++ b/custom_components/v2c_cloud/sensor.py
@@ -560,10 +560,10 @@ class V2CTransportSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity)
     """
     Diagnostic sensor naming the transport currently carrying the data.
 
-    Exists because the failure mode in issue #54 was invisible: a Wi-Fi
-    install silently fell back to cloud synthesis, and the only clue was that
-    every LAN reading went Unknown. The state answers "LAN, cloud, or nothing",
-    and the attributes say which address is in use and where it came from.
+    Exists because that failure mode was otherwise invisible: a Wi-Fi install
+    could silently fall back to cloud synthesis, with every LAN reading going
+    Unknown as the only clue. The state answers "LAN, cloud, or nothing", and
+    the attributes say which address is in use and where it came from.
     """
 
     _attr_has_entity_name = True

--- a/tests/test_cloud_only_availability.py
+++ b/tests/test_cloud_only_availability.py
@@ -177,13 +177,13 @@ class TestUnauthenticatedCloudGating:
     """
     A control with no LAN route must go Unavailable when the cloud is out.
 
-    During the V2C auth outage (issue #54) the integration kept running over
-    the LAN, which is the point — but OCPP and the RFID reader, which exist
-    only in the cloud API, stayed available and toggleable. Pressing one
-    raised deep inside the client and changed nothing on the charger, while
-    the switch went on displaying a state it had never received. The
-    integration's own log said "cloud-only controls are unavailable until it
-    recovers"; nothing in the code made that true.
+    Degrading to LAN on an authentication failure keeps the integration
+    running, which is the point — but OCPP and the RFID reader, which exist
+    only in the cloud API, used to stay available and toggleable regardless.
+    Pressing one raised deep inside the client and changed nothing on the
+    charger, while the switch went on displaying a state it had never
+    received. The integration's own log said "cloud-only controls are
+    unavailable until it recovers"; nothing in the code made that true.
     """
 
     def _switch(self, *, local_keys: tuple[str, ...], cloud_ok: bool) -> object:

--- a/tests/test_cloud_outage_resilience.py
+++ b/tests/test_cloud_outage_resilience.py
@@ -1,8 +1,8 @@
 """
-Resilience of a LAN entry to a total V2C Cloud outage (issue #54).
+Resilience of a LAN entry to a total V2C Cloud outage.
 
-The V2C Cloud rejected valid API keys for days. Every LAN install went dark
-with it, because:
+If the V2C Cloud rejects valid API keys for an extended period, every LAN
+install used to go dark with it, because:
 
 * an authentication failure raised `ConfigEntryAuthFailed` unconditionally, so
   the entry was torn down even though the charger was reachable over HTTP; and
@@ -433,8 +433,8 @@ class TestRejectedKeyIsReportedNotSwallowed:
 
     The cloud answers a rejected key with an empty-bodied 401, so the raw
     exception reads "V2C authentication failed: " and nothing more. Pressing
-    the OCPP switch during the outage put that, plus a traceback, in the log
-    and left the UI with no explanation at all.
+    the OCPP switch while the cloud is unauthenticated used to put that, plus
+    a traceback, in the log and leave the UI with no explanation at all.
     """
 
     async def test_entity_command_raises_a_readable_error(self) -> None:

--- a/tests/test_lan_only_setup.py
+++ b/tests/test_lan_only_setup.py
@@ -1,5 +1,5 @@
 """
-Phase 2 of the issue #54 plan: running without a reachable V2C cloud.
+Running without a reachable V2C cloud.
 
 Covers the schema v3 additions (`manual_ips`, `lan_only`), the account-less
 config-flow branch, and the per-charger IP overrides in the options flow.

--- a/tests/test_unload.py
+++ b/tests/test_unload.py
@@ -1,7 +1,7 @@
 """
 Tests for `async_unload_entry` — local-coordinator shutdown.
 
-Regression cover for the bug reported through a user log in issue #54:
+Regression cover for a bug found in a user's log:
 `DataUpdateCoordinator.async_shutdown` is a coroutine function, and it was
 being CALLED but never AWAITED. The visible symptom was
 `RuntimeWarning: coroutine 'DataUpdateCoordinator.async_shutdown' was never


### PR DESCRIPTION
Removes references to the specific, temporary V2C-side authentication fault (issue #54) from code, docstrings, tests, and both READMEs — it stays only in the issue that tracks it.

## Rationale

A code comment or a published README persists long after a vendor-side incident is resolved. Citing "issue #54" or "the Sept 2026 outage" by name in those places dates the codebase to a transient event instead of describing the permanent engineering property the code actually has: the integration tolerates a cloud that rejects a valid key or is unreachable, regardless of why.

## Changes

- **README (both copies)**: dropped the outage banner naming the date and linking the issue, and the self-reference to it further down. The "Running without the cloud" section already described the capability generically — kept as-is.
- **Code comments/docstrings** (`config_flow.py`, `__init__.py`, `sensor.py`, `local_api.py`): reworded to state the general condition ("the cloud can reject a valid key for extended periods") instead of citing the incident.
- **Test docstrings** (`test_cloud_outage_resilience.py`, `test_lan_only_setup.py`, `test_cloud_only_availability.py`, `test_unload.py`): same treatment.

No behavior, test, or feature changed — 614 tests still passing. `Task Board.md` and `Daily Notes/` are left as-is: they're session working-memory, not published documentation, and the point of a daily note is to record what actually happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
