### PR TITLE
fix: recover from a charger's LAN address changing — 1.4.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0-beta.9] - 2026-09-12
+
+### Fixed
+
+- **A charger whose LAN address changes is found again on its own.** When DHCP
+  moved a charger to a new address, the integration kept calling the old one
+  until somebody set the address by hand: every poll tried a single address,
+  and an address the cloud advertised outranked one the charger had actually
+  answered on — so even after a successful local fetch recorded the working
+  address, the stale one won again on the next cycle. Address selection now
+  puts a LAN-verified address above anything the cloud reports, and a poll that
+  fails falls through to the other addresses it knows before giving up on the
+  local connection. A manual override is still absolute: it is tried alone, so
+  a wrong pinned address fails visibly instead of being silently worked around.
+- Within the cloud's own data, the address the charger reports for itself is
+  now preferred over the static address registered in the V2C portal, which
+  only changes when somebody edits it and is the one that goes stale.
+- A local response is accepted only when it actually looks like Trydan
+  real-time data. A released DHCP lease is often picked up by some other
+  device, and a neighbour serving JSON can no longer be mistaken for the
+  charger.
+
+### Changed
+
+- **Contracted power can now be set down to -5 kW** (previously the slider
+  stopped at 1 kW). A negative contracted power is how an installation tells
+  the dynamic-power algorithm to reserve headroom for the rest of the house
+  rather than to declare a contract size; the local register is signed, but the
+  entity's lower bound put that configuration out of reach.
+
 ## [1.4.0-beta.8] - 2026-09-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ The V2C Cloud is not always reachable — rate limits, connectivity issues, or a
 An account can be added later by re-running setup with the cloud path — the two are independent entries, not a migration.
 
 ### Pin a manual IP address
-For an existing **Local (Wi-Fi)** entry, go to **Settings → Devices & Services → V2C Cloud → Configure**, tick **Set charger IP addresses manually**, and enter an address for each charger (one form per charger, so the field stays properly labelled). Precedence is: **manual override → address discovered from the cloud → cached address → address seen in the last local payload.**
+For an existing **Local (Wi-Fi)** entry, go to **Settings → Devices & Services → V2C Cloud → Configure**, tick **Set charger IP addresses manually**, and enter an address for each charger (one form per charger, so the field stays properly labelled). Precedence is: **manual override → address last verified on the LAN → address discovered from the cloud → cached address → address seen in the last local payload.**
+
+A manual override is absolute: it is the only address tried, so a wrong entry fails visibly rather than being worked around. Without one, a poll that cannot reach the charger tries the other addresses it knows before falling back to cloud data, so a charger moved by DHCP is picked up again without intervention.
 
 This matters most when the cloud can't currently supply an address — which is exactly when you'd otherwise have no way to tell the integration where the charger is. The options dialog shows the addresses currently on file; leaving the box ticked with an empty field, or unticking it, removes the override and hands the address back to cloud discovery.
 
@@ -104,7 +106,7 @@ This matters most when the cloud can't currently supply an address — which is 
 - **Either way, controls with no local equivalent go unavailable** rather than silently failing: OCPP, the RFID reader, installation type, slave device, language, the reboot and firmware-update buttons, and the cloud-connection binary sensor. They recover automatically as soon as the cloud does.
 
 ### `Active transport` diagnostic sensor
-One per charger, reporting `Local network`, `V2C Cloud`, or `Offline`, with the address in use and where it came from (`manual`, `cloud`, `cache`, or the last local payload) exposed as attributes. It's the fastest way to see, at a glance, what the integration is actually doing for a given charger right now.
+One per charger, reporting `Local network`, `V2C Cloud`, or `Offline`, with the address in use and where it came from (`manual`, `lan` for an address verified on the local network, `cloud`, `cache`, or the last local payload) exposed as attributes. It's the fastest way to see, at a glance, what the integration is actually doing for a given charger right now.
 
 ## Entity Overview
 
@@ -145,7 +147,9 @@ Entities backed by a cloud-only endpoint (marked *cloud* below, plus the diagnos
 - Current intensity (local `/write/Intensity`)
 - Minimum intensity (local `/write/MinIntensity`)
 - Maximum intensity (local `/write/MaxIntensity`)
-- Contracted power (local `/write/ContractedPower`, auto-converted between watts and kW)
+- Contracted power — -5 to 22 kW (local `/write/ContractedPower`, auto-converted
+  between watts and kW). Negative values reserve headroom for the rest of the
+  installation instead of declaring a contract size.
 - Light LED intensity — 0-100 % (local `/write/LightLED`)
 
 ### Buttons

--- a/custom_components/v2c_cloud/README.md
+++ b/custom_components/v2c_cloud/README.md
@@ -94,7 +94,9 @@ The V2C Cloud is not always reachable — rate limits, connectivity issues, or a
 An account can be added later by re-running setup with the cloud path — the two are independent entries, not a migration.
 
 ### Pin a manual IP address
-For an existing **Local (Wi-Fi)** entry, go to **Settings → Devices & Services → V2C Cloud → Configure**, tick **Set charger IP addresses manually**, and enter an address for each charger (one form per charger, so the field stays properly labelled). Precedence is: **manual override → address discovered from the cloud → cached address → address seen in the last local payload.**
+For an existing **Local (Wi-Fi)** entry, go to **Settings → Devices & Services → V2C Cloud → Configure**, tick **Set charger IP addresses manually**, and enter an address for each charger (one form per charger, so the field stays properly labelled). Precedence is: **manual override → address last verified on the LAN → address discovered from the cloud → cached address → address seen in the last local payload.**
+
+A manual override is absolute: it is the only address tried, so a wrong entry fails visibly rather than being worked around. Without one, a poll that cannot reach the charger tries the other addresses it knows before falling back to cloud data, so a charger moved by DHCP is picked up again without intervention.
 
 This matters most when the cloud can't currently supply an address — which is exactly when you'd otherwise have no way to tell the integration where the charger is. The options dialog shows the addresses currently on file; leaving the box ticked with an empty field, or unticking it, removes the override and hands the address back to cloud discovery.
 
@@ -104,7 +106,7 @@ This matters most when the cloud can't currently supply an address — which is 
 - **Either way, controls with no local equivalent go unavailable** rather than silently failing: OCPP, the RFID reader, installation type, slave device, language, the reboot and firmware-update buttons, and the cloud-connection binary sensor. They recover automatically as soon as the cloud does.
 
 ### `Active transport` diagnostic sensor
-One per charger, reporting `Local network`, `V2C Cloud`, or `Offline`, with the address in use and where it came from (`manual`, `cloud`, `cache`, or the last local payload) exposed as attributes. It's the fastest way to see, at a glance, what the integration is actually doing for a given charger right now.
+One per charger, reporting `Local network`, `V2C Cloud`, or `Offline`, with the address in use and where it came from (`manual`, `lan` for an address verified on the local network, `cloud`, `cache`, or the last local payload) exposed as attributes. It's the fastest way to see, at a glance, what the integration is actually doing for a given charger right now.
 
 ## Entity Overview
 
@@ -145,7 +147,9 @@ Entities backed by a cloud-only endpoint (marked *cloud* below, plus the diagnos
 - Current intensity (local `/write/Intensity`)
 - Minimum intensity (local `/write/MinIntensity`)
 - Maximum intensity (local `/write/MaxIntensity`)
-- Contracted power (local `/write/ContractedPower`, auto-converted between watts and kW)
+- Contracted power — -5 to 22 kW (local `/write/ContractedPower`, auto-converted
+  between watts and kW). Negative values reserve headroom for the rest of the
+  installation instead of declaring a contract size.
 - Light LED intensity — 0-100 % (local `/write/LightLED`)
 
 ### Buttons

--- a/custom_components/v2c_cloud/const.py
+++ b/custom_components/v2c_cloud/const.py
@@ -54,9 +54,14 @@ LOCAL_WRITE_RETRY_DELAY = 5
 # Cloud-only mode (4G Trydan, no LAN reachability)
 CLOUD_ONLY_UPDATE_INTERVAL = timedelta(seconds=120)
 
-# Power limits (kW)
-MAX_POWER_MIN_KW = 1.0
-MAX_POWER_MAX_KW = 22.0
+# Contracted-power limits (kW) for the ContractedPower number entity.
+# The lower bound is deliberately negative: on a Trydan, a negative
+# ContractedPower is how an installation tells the dynamic-power algorithm to
+# reserve headroom for the rest of the house rather than to declare a contract
+# size, and the LAN /write/ContractedPower register accepts the signed value.
+# Clamping at 1 kW made that configuration unreachable from Home Assistant.
+CONTRACTED_POWER_MIN_KW = -5.0
+CONTRACTED_POWER_MAX_KW = 22.0
 INSTALLATION_VOLTAGE_MIN = 100.0
 INSTALLATION_VOLTAGE_MAX = 450.0
 

--- a/custom_components/v2c_cloud/local_api.py
+++ b/custom_components/v2c_cloud/local_api.py
@@ -433,6 +433,28 @@ def _ip_from_manual_override(
     return manual_ip_for(runtime_data, device_id)
 
 
+def _ip_from_lan_verified(
+    runtime_data: V2CEntryRuntimeData, device_id: str
+) -> str | None:
+    """
+    The address that most recently answered ``/RealTimeData`` on the LAN.
+
+    ``_static_ip`` is stamped onto the payload only by a successful local
+    fetch, so its presence on a non-synthesised payload is direct evidence
+    that this address reached this charger. Everything below this source is
+    hearsay by comparison — the cloud repeats what it was last told, and the
+    cache repeats what the cloud last said — which is why a DHCP move used to
+    strand the integration on a dead address: the proven one was persisted
+    into ``cached_pairings``, a source the stale cloud value outranks.
+    """
+    local_coordinator = runtime_data.local_coordinators.get(device_id)
+    data = getattr(local_coordinator, "data", None) if local_coordinator else None
+    if not isinstance(data, dict) or payload_is_cloud_synthesised(data):
+        return None
+    verified = data.get("_static_ip")
+    return verified if isinstance(verified, str) and verified else None
+
+
 def _ip_from_cloud_runtime(
     runtime_data: V2CEntryRuntimeData, device_id: str
 ) -> str | None:
@@ -440,17 +462,21 @@ def _ip_from_cloud_runtime(
     device_state = get_device_state_from_coordinator(
         runtime_data.coordinator, device_id
     )
-    additional = device_state.get("additional")
-    if isinstance(additional, dict):
-        static_ip = additional.get("static_ip")
-        if isinstance(static_ip, str) and static_ip:
-            return static_ip
-
+    # The charger re-uploads its own address on every cloud check-in, whereas
+    # ``additional.static_ip`` is a registration field that only changes when
+    # somebody edits it in the V2C portal. When the two disagree it is the
+    # portal that has gone stale, so the self-report is consulted first.
     reported = device_state.get("reported")
     if isinstance(reported, dict):
         candidate = reported.get("ip") or reported.get("wifi_ip")
         if isinstance(candidate, str) and candidate:
             return candidate
+
+    additional = device_state.get("additional")
+    if isinstance(additional, dict):
+        static_ip = additional.get("static_ip")
+        if isinstance(static_ip, str) and static_ip:
+            return static_ip
 
     data = getattr(runtime_data.coordinator, "data", None)
     pairings = data.get("pairings") if isinstance(data, dict) else None
@@ -493,14 +519,19 @@ def _ip_in_records(records: object, device_id: str) -> str | None:
 
 
 # Address sources in priority order. The user's explicit override wins, then
-# live cloud data, then the persisted cache, then whatever the charger last
-# told us about itself. Steps 1 and 3 are what keep the LAN transport alive
-# during a total cloud outage: without them every source would be derived
-# from live cloud data, so an authentication failure would leave the
-# integration with no address at all and silently degrade a LAN install to
-# cloud-only behaviour.
+# an address that has actually answered on the LAN, then live cloud data, then
+# the persisted cache, then whatever the charger last told us about itself.
+# Steps 1, 2 and 4 are what keep the LAN transport alive during a total cloud
+# outage: without them every source would be derived from live cloud data, so
+# an authentication failure would leave the integration with no address at all
+# and silently degrade a LAN install to cloud-only behaviour.
+#
+# Ordering rule: evidence outranks hearsay. Only the manual override sits above
+# the LAN-verified address, because that override is a deliberate statement by
+# the user rather than a guess the integration made on its own.
 _IP_SOURCES: tuple[Callable[[V2CEntryRuntimeData, str], str | None], ...] = (
     _ip_from_manual_override,
+    _ip_from_lan_verified,
     _ip_from_cloud_runtime,
     _ip_from_offline_cache,
     _ip_from_local_payload,
@@ -510,6 +541,7 @@ _IP_SOURCES: tuple[Callable[[V2CEntryRuntimeData, str], str | None], ...] = (
 # Human-readable label per address source, for the diagnostic sensor.
 _IP_SOURCE_LABELS: dict[str, str] = {
     "_ip_from_manual_override": "manual",
+    "_ip_from_lan_verified": "lan",
     "_ip_from_cloud_runtime": "cloud",
     "_ip_from_offline_cache": "cache",
     "_ip_from_local_payload": "charger",
@@ -525,6 +557,18 @@ def describe_ip_source(
         if candidate:
             return candidate, _IP_SOURCE_LABELS.get(source.__name__)
     return None, None
+
+
+def _looks_like_realtime(payload: dict[str, Any]) -> bool:
+    """
+    True when a parsed payload really came from a Trydan charger.
+
+    Used before adopting an address that is not the charger's best-known one:
+    any host can serve JSON, and a DHCP lease that has moved on to some other
+    device must not be mistaken for the charger.
+    """
+    index = payload.get("_lower_index")
+    return isinstance(index, dict) and "chargestate" in index
 
 
 def payload_is_cloud_synthesised(data: object) -> bool:
@@ -572,6 +616,36 @@ def resolve_static_ip(runtime_data: V2CEntryRuntimeData, device_id: str) -> str 
         if candidate:
             return candidate
     return None
+
+
+def candidate_ips(runtime_data: V2CEntryRuntimeData, device_id: str) -> list[str]:
+    """
+    Return every address worth trying for a charger, best first.
+
+    A manual override is returned alone. The user pinned that address on
+    purpose, so quietly succeeding against a different one would hide the very
+    misconfiguration the override exists to express — better to fail visibly.
+
+    Otherwise the known addresses are returned in source order, de-duplicated
+    and filtered through the SSRF guard. Having more than one matters when the
+    charger's address changes under DHCP: the stale entry is tried first and
+    fails, and the poll can still find the charger at one of the others
+    instead of waiting for a human to notice.
+    """
+    manual = _ip_from_manual_override(runtime_data, device_id)
+    if manual:
+        is_safe, _err = validate_private_ip(manual)
+        return [manual] if is_safe else []
+
+    candidates: list[str] = []
+    for source in _IP_SOURCES:
+        candidate = source(runtime_data, device_id)
+        if not candidate or candidate in candidates:
+            continue
+        is_safe, _err = validate_private_ip(candidate)
+        if is_safe:
+            candidates.append(candidate)
+    return candidates
 
 
 def get_local_data(
@@ -794,6 +868,77 @@ async def async_route_local_or_cloud(  # noqa: PLR0913
     _LOGGER.debug("V2C router: cloud path used for %s/%s", device_id, keyword)
 
 
+async def _async_fetch_realtime(
+    session: ClientSession, device_id: str, ip: str, retries: int
+) -> dict[str, Any]:
+    """
+    GET and parse ``/RealTimeData`` from one address.
+
+    Raises ``UpdateFailed`` when the address does not answer within ``retries``
+    attempts, or answers with something that is not a usable RealTimeData
+    document.
+    """
+    url = f"http://{ip}/RealTimeData"
+    attempt = 1
+    last_error: Exception | None = None
+    while True:
+        try:
+            async with (
+                async_timeout.timeout(LOCAL_TIMEOUT),
+                session.get(url) as response,
+            ):
+                text = await response.text()
+            break
+        except TimeoutError as err:
+            last_error = err
+            error_message = "Timeout while fetching local real-time data"
+        except ClientError as err:
+            last_error = err
+            error_message = f"Error while fetching local real-time data: {err}"
+
+        if attempt >= retries:
+            raise UpdateFailed(
+                f"{error_message} after {retries} attempt(s)"
+            ) from last_error
+
+        delay = LOCAL_RETRY_BACKOFF * attempt
+        _LOGGER.debug(
+            "Local realtime fetch failed for %s at %s (attempt %s/%s): %s. "
+            "Retrying in %.1f s",
+            device_id,
+            ip,
+            attempt,
+            retries,
+            last_error,
+            delay,
+        )
+        attempt += 1
+        await asyncio.sleep(delay)
+
+    payload_text = text.strip().rstrip("%").strip()
+    if not payload_text:
+        raise UpdateFailed("Empty response from local RealTimeData endpoint")
+
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError as err:
+        raise UpdateFailed(
+            f"Invalid JSON response from local endpoint: {payload_text}"
+        ) from err
+
+    if not isinstance(payload, dict):
+        raise UpdateFailed("Unexpected payload type from local endpoint")
+
+    payload["_static_ip"] = ip
+
+    # Normalise documented key spellings before anything reads the payload.
+    _normalise_realtime_keys(payload)
+
+    # Pre-build a lowercase-key → original-key index for O(1) case-insensitive lookups.
+    payload["_lower_index"] = {k.lower(): k for k in payload if not k.startswith("_")}
+    return payload
+
+
 async def async_get_or_create_local_coordinator(
     hass: HomeAssistant,
     runtime_data: V2CEntryRuntimeData,
@@ -818,84 +963,62 @@ async def async_get_or_create_local_coordinator(
         if entry_data.get("cloud_only"):
             return _build_realtime_from_reported(runtime_data, device_id)
 
-        static_ip = resolve_static_ip(runtime_data, device_id)
-        if not static_ip:
-            # No IP found anywhere → cloud-only fallback
-            return _build_realtime_from_reported(runtime_data, device_id)
-        is_safe, _err = validate_private_ip(static_ip)
-        if not is_safe:
-            # Invalid / non-routable IP → cloud-only fallback
+        candidates = candidate_ips(runtime_data, device_id)
+        if not candidates:
+            # No usable IP found anywhere → cloud-only fallback
             return _build_realtime_from_reported(runtime_data, device_id)
 
-        url = f"http://{static_ip}/RealTimeData"
-        attempt = 1
-        last_error: Exception | None = None
-        while True:
+        payload: dict[str, Any] | None = None
+        static_ip = ""
+        last_failure: UpdateFailed | None = None
+        for index, ip in enumerate(candidates):
+            # Only the best candidate gets the full retry budget. The rest are
+            # long shots on an already-failing poll and are tried once each, so
+            # a charger that moved is still found without the fetch outlasting
+            # the poll interval.
+            retries = LOCAL_MAX_RETRIES if index == 0 else 1
             try:
-                async with (
-                    async_timeout.timeout(LOCAL_TIMEOUT),
-                    session.get(url) as response,
-                ):
-                    text = await response.text()
-                break
-            except TimeoutError as err:
-                last_error = err
-                error_message = "Timeout while fetching local real-time data"
-            except ClientError as err:
-                last_error = err
-                error_message = f"Error while fetching local real-time data: {err}"
+                found = await _async_fetch_realtime(session, device_id, ip, retries)
+            except UpdateFailed as err:
+                last_failure = err
+                continue
+            if not _looks_like_realtime(found):
+                # Something answered, but it is not the charger. A vacated DHCP
+                # lease gets handed to another device, and that device may well
+                # serve JSON of its own — adopting it would fill the entities
+                # with a stranger's data.
+                _LOGGER.debug(
+                    "V2C %s: %s answered but the payload is not RealTimeData; ignoring",
+                    device_id,
+                    ip,
+                )
+                continue
+            if index:
+                _LOGGER.info(
+                    "V2C %s: %s stopped answering; found the charger at %s instead "
+                    "and adopted the new address",
+                    device_id,
+                    candidates[0],
+                    ip,
+                )
+            payload, static_ip = found, ip
+            break
 
-            if attempt >= LOCAL_MAX_RETRIES:
-                failure_count += 1
-                # Fall back to cloud data instead of failing entirely
-                cloud_payload = _build_realtime_from_reported(runtime_data, device_id)
-                if cloud_payload.get("_data_source") != "cloud_reported_empty":
-                    _LOGGER.debug(
-                        "Local API unreachable for %s after %s attempt(s), "
-                        "falling back to cloud reported data",
-                        device_id,
-                        LOCAL_MAX_RETRIES,
-                    )
-                    return cloud_payload
-                raise UpdateFailed(
-                    f"{error_message} after {LOCAL_MAX_RETRIES} attempt(s)"
-                ) from last_error
-
-            delay = LOCAL_RETRY_BACKOFF * attempt
-            _LOGGER.debug(
-                "Local realtime fetch failed for %s (attempt %s/%s): %s. Retrying in %.1f s",
-                device_id,
-                attempt,
-                LOCAL_MAX_RETRIES,
-                last_error,
-                delay,
+        if payload is None:
+            failure_count += 1
+            # Fall back to cloud data instead of failing entirely
+            cloud_payload = _build_realtime_from_reported(runtime_data, device_id)
+            if cloud_payload.get("_data_source") != "cloud_reported_empty":
+                _LOGGER.debug(
+                    "Local API unreachable for %s at %s, falling back to cloud "
+                    "reported data",
+                    device_id,
+                    ", ".join(candidates),
+                )
+                return cloud_payload
+            raise last_failure or UpdateFailed(
+                "Local RealTimeData unreachable and no cloud data available"
             )
-            attempt += 1
-            await asyncio.sleep(delay)
-
-        payload_text = text.strip().rstrip("%").strip()
-        if not payload_text:
-            raise UpdateFailed("Empty response from local RealTimeData endpoint")
-
-        try:
-            payload = json.loads(payload_text)
-        except json.JSONDecodeError as err:
-            raise UpdateFailed(
-                f"Invalid JSON response from local endpoint: {payload_text}"
-            ) from err
-
-        if not isinstance(payload, dict):
-            raise UpdateFailed("Unexpected payload type from local endpoint")
-
-        payload["_static_ip"] = static_ip
-
-        # Normalise documented key spellings before anything reads the payload.
-        _normalise_realtime_keys(payload)
-
-        # Pre-build a lowercase-key → original-key index for O(1) case-insensitive lookups.
-        payload["_lower_index"] = {
-            k.lower(): k for k in payload if not k.startswith("_")
-        }
 
         # Fetch writable keys absent from /RealTimeData (e.g. LogoLED)
         extra = await asyncio.gather(

--- a/custom_components/v2c_cloud/manifest.json
+++ b/custom_components/v2c_cloud/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/samuelebistoletti/HomeAssistant-V2C-Cloud/issues",
   "requirements": [],
-  "version": "1.4.0-beta.8"
+  "version": "1.4.0-beta.9"
 }

--- a/custom_components/v2c_cloud/number.py
+++ b/custom_components/v2c_cloud/number.py
@@ -15,9 +15,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
+    CONTRACTED_POWER_MAX_KW,
+    CONTRACTED_POWER_MIN_KW,
     DOMAIN,
-    MAX_POWER_MAX_KW,
-    MAX_POWER_MIN_KW,
 )
 from .entity import V2CEntity, _OptimisticHoldMixin
 from .local_api import (
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 CURRENT_MIN = 6.0
 CURRENT_MAX = 32.0
 CURRENT_STEP = 1.0
-POWER_MIN = MAX_POWER_MIN_KW
-POWER_MAX = MAX_POWER_MAX_KW
+POWER_MIN = CONTRACTED_POWER_MIN_KW
+POWER_MAX = CONTRACTED_POWER_MAX_KW
 POWER_STEP = 0.5
 
 

--- a/tests/test_dhcp_address_recovery.py
+++ b/tests/test_dhcp_address_recovery.py
@@ -94,7 +94,9 @@ class TestLanVerifiedOutranksCloud:
 
     def test_proven_address_beats_stale_cached_pairing(self):
         runtime = _runtime(
-            entry_data={CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": STALE_IP}]},
+            entry_data={
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": STALE_IP}]
+            },
             local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
         )
         assert resolve_static_ip(runtime, DEVICE_ID) == LIVE_IP
@@ -173,18 +175,16 @@ class TestCandidateIps:
                 CONF_MANUAL_IPS: {DEVICE_ID: STALE_IP},
                 CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
             },
-            coordinator_data={
-                "devices": {DEVICE_ID: {"reported": {"ip": THIRD_IP}}}
-            },
+            coordinator_data={"devices": {DEVICE_ID: {"reported": {"ip": THIRD_IP}}}},
         )
         assert candidate_ips(runtime, DEVICE_ID) == [STALE_IP]
 
     def test_every_known_address_is_offered_best_first(self):
         runtime = _runtime(
-            entry_data={CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": THIRD_IP}]},
-            coordinator_data={
-                "devices": {DEVICE_ID: {"reported": {"ip": STALE_IP}}}
+            entry_data={
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": THIRD_IP}]
             },
+            coordinator_data={"devices": {DEVICE_ID: {"reported": {"ip": STALE_IP}}}},
             local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
         )
         assert candidate_ips(runtime, DEVICE_ID) == [LIVE_IP, STALE_IP, THIRD_IP]
@@ -192,9 +192,7 @@ class TestCandidateIps:
     def test_duplicates_collapse(self):
         runtime = _runtime(
             entry_data={CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}]},
-            coordinator_data={
-                "devices": {DEVICE_ID: {"reported": {"ip": LIVE_IP}}}
-            },
+            coordinator_data={"devices": {DEVICE_ID: {"reported": {"ip": LIVE_IP}}}},
             local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
         )
         assert candidate_ips(runtime, DEVICE_ID) == [LIVE_IP]

--- a/tests/test_dhcp_address_recovery.py
+++ b/tests/test_dhcp_address_recovery.py
@@ -1,0 +1,357 @@
+"""
+Recovery when the charger's LAN address changes under it.
+
+A Trydan on DHCP can be handed a new address at any time. Before these tests
+the integration could not notice: `resolve_static_ip` ranked cloud-advertised
+addresses above everything the LAN had actually proven, and the poll only ever
+tried the single best-ranked address. So a lease change stranded a healthy LAN
+install on a dead address — the poll hammered the old one, fell back to cloud
+data, and stayed there until a human typed the new address into the options.
+
+Worse, the self-healing that did exist was defeated by the ordering:
+`_persist_lan_observed_ip` writes a proven address into `cached_pairings`,
+which sits BELOW the stale cloud value, so the proof was recorded and then
+immediately outranked on the next poll.
+
+These tests pin the two properties that fix it: evidence outranks hearsay when
+choosing an address, and a failing poll tries the other addresses it knows
+before giving up on the LAN.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.v2c_cloud.const import (
+    CONF_CACHED_PAIRINGS,
+    CONF_CLOUD_ONLY,
+    CONF_MANUAL_IPS,
+)
+from custom_components.v2c_cloud.local_api import (
+    candidate_ips,
+    describe_ip_source,
+    resolve_static_ip,
+)
+
+DEVICE_ID = "XQUXDU"
+# The live addresses from the incident this test file was written for: the
+# charger moved from .60 to .50 and the integration kept calling .60.
+STALE_IP = "10.35.0.60"
+LIVE_IP = "10.35.0.50"
+THIRD_IP = "10.35.0.77"
+
+REALTIME_BODY = '{"ChargeState":2,"ChargePower":7360,"Intensity":32}'
+
+
+@pytest.fixture(autouse=True)
+def no_sleep():
+    """Disable real sleeps so retry backoff is instantaneous."""
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        yield
+
+
+def _runtime(
+    *,
+    entry_data: dict[str, Any] | None = None,
+    coordinator_data: Any = None,
+    local_data: Any = None,
+) -> MagicMock:
+    """Build a runtime-data double with a mappingproxy ``entry.data``."""
+    runtime = MagicMock()
+    runtime.coordinator.config_entry.data = MappingProxyType(dict(entry_data or {}))
+    runtime.coordinator.config_entry.options = {}
+    runtime.coordinator.data = coordinator_data
+    if local_data is None:
+        runtime.local_coordinators = {}
+    else:
+        local = MagicMock()
+        local.data = local_data
+        runtime.local_coordinators = {DEVICE_ID: local}
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# Which address wins
+# ---------------------------------------------------------------------------
+
+
+class TestLanVerifiedOutranksCloud:
+    """An address that answered on the LAN beats one the cloud merely claims."""
+
+    def test_proven_address_beats_stale_cloud_static_ip(self):
+        runtime = _runtime(
+            coordinator_data={
+                "devices": {DEVICE_ID: {"additional": {"static_ip": STALE_IP}}}
+            },
+            local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == LIVE_IP
+        assert describe_ip_source(runtime, DEVICE_ID) == (LIVE_IP, "lan")
+
+    def test_proven_address_beats_stale_cached_pairing(self):
+        runtime = _runtime(
+            entry_data={CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": STALE_IP}]},
+            local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == LIVE_IP
+
+    def test_manual_override_still_outranks_a_proven_address(self):
+        """The user's explicit choice is a decision, not a guess to be improved."""
+        runtime = _runtime(
+            entry_data={CONF_MANUAL_IPS: {DEVICE_ID: STALE_IP}},
+            local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == STALE_IP
+        assert describe_ip_source(runtime, DEVICE_ID) == (STALE_IP, "manual")
+
+    def test_cloud_synthesised_payload_is_not_evidence(self):
+        """
+        A synthesised payload carries an address the cloud supplied, not one
+        the LAN proved. Promoting it would make the cloud outrank itself.
+        """
+        runtime = _runtime(
+            coordinator_data={
+                "devices": {DEVICE_ID: {"additional": {"static_ip": STALE_IP}}}
+            },
+            local_data={
+                "_data_source": "cloud_reported",
+                "IP": LIVE_IP,
+                "_static_ip": LIVE_IP,
+            },
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == STALE_IP
+        assert describe_ip_source(runtime, DEVICE_ID)[1] == "cloud"
+
+
+class TestChargerSelfReportBeatsPortalField:
+    """Inside the cloud payload, the charger's own report is the fresher one."""
+
+    def test_reported_ip_wins_over_additional_static_ip(self):
+        runtime = _runtime(
+            coordinator_data={
+                "devices": {
+                    DEVICE_ID: {
+                        "additional": {"static_ip": STALE_IP},
+                        "reported": {"ip": LIVE_IP},
+                    }
+                }
+            }
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == LIVE_IP
+
+    def test_additional_static_ip_still_used_when_nothing_reported(self):
+        runtime = _runtime(
+            coordinator_data={
+                "devices": {
+                    DEVICE_ID: {"additional": {"static_ip": STALE_IP}, "reported": {}}
+                }
+            }
+        )
+        assert resolve_static_ip(runtime, DEVICE_ID) == STALE_IP
+
+
+# ---------------------------------------------------------------------------
+# The candidate list
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateIps:
+    """What the poll is allowed to try, and in what order."""
+
+    def test_manual_override_is_returned_alone(self):
+        """
+        Pinning an address is a statement about where the charger must be.
+        Succeeding quietly at some other address would hide the mistake the
+        override exists to make visible.
+        """
+        runtime = _runtime(
+            entry_data={
+                CONF_MANUAL_IPS: {DEVICE_ID: STALE_IP},
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
+            },
+            coordinator_data={
+                "devices": {DEVICE_ID: {"reported": {"ip": THIRD_IP}}}
+            },
+        )
+        assert candidate_ips(runtime, DEVICE_ID) == [STALE_IP]
+
+    def test_every_known_address_is_offered_best_first(self):
+        runtime = _runtime(
+            entry_data={CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": THIRD_IP}]},
+            coordinator_data={
+                "devices": {DEVICE_ID: {"reported": {"ip": STALE_IP}}}
+            },
+            local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
+        )
+        assert candidate_ips(runtime, DEVICE_ID) == [LIVE_IP, STALE_IP, THIRD_IP]
+
+    def test_duplicates_collapse(self):
+        runtime = _runtime(
+            entry_data={CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}]},
+            coordinator_data={
+                "devices": {DEVICE_ID: {"reported": {"ip": LIVE_IP}}}
+            },
+            local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
+        )
+        assert candidate_ips(runtime, DEVICE_ID) == [LIVE_IP]
+
+    def test_non_routable_candidates_are_dropped(self):
+        """The SSRF guard applies to every candidate, not just the first."""
+        runtime = _runtime(
+            entry_data={
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": "8.8.8.8"}]
+            },
+            coordinator_data={
+                "devices": {DEVICE_ID: {"reported": {"ip": "127.0.0.1"}}}
+            },
+            local_data={"_static_ip": LIVE_IP, "ChargeState": 2},
+        )
+        assert candidate_ips(runtime, DEVICE_ID) == [LIVE_IP]
+
+    def test_unsafe_manual_override_yields_nothing(self):
+        runtime = _runtime(
+            entry_data={
+                CONF_MANUAL_IPS: {DEVICE_ID: "169.254.1.1"},
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
+            }
+        )
+        assert candidate_ips(runtime, DEVICE_ID) == []
+
+    def test_no_addresses_at_all(self):
+        assert candidate_ips(_runtime(), DEVICE_ID) == []
+
+
+# ---------------------------------------------------------------------------
+# The poll actually finding the charger again
+# ---------------------------------------------------------------------------
+
+
+class TestPollRecoversFromAddressChange:
+    """Drive the real coordinator against a charger that has moved."""
+
+    async def _coordinator(
+        self, *, entry_data, serve: dict[str, str], cloud_ip: str | None = None
+    ):
+        """
+        Build a real local coordinator.
+
+        ``serve`` maps address -> response body; any address outside it
+        refuses the connection, which is what a vacated DHCP lease looks like.
+        ``cloud_ip`` is what the cloud claims, which outranks the cache — the
+        two sources are how a poll ends up with more than one candidate, since
+        the pairings cache only ever holds one address per charger.
+        """
+        from aiohttp import ClientSession
+        from aioresponses import aioresponses
+
+        from custom_components.v2c_cloud.local_api import (
+            async_get_or_create_local_coordinator,
+        )
+
+        reported = {"ip": cloud_ip} if cloud_ip else {}
+        runtime = _runtime(
+            entry_data=entry_data,
+            coordinator_data={"devices": {DEVICE_ID: {"reported": reported}}},
+        )
+
+        session = ClientSession()
+        try:
+            with (
+                aioresponses() as m,
+                patch(
+                    "custom_components.v2c_cloud.local_api.async_get_clientsession",
+                    return_value=session,
+                ),
+                patch(
+                    "custom_components.v2c_cloud.local_api._persist_lan_observed_ip"
+                ) as persist,
+            ):
+                for ip, body in serve.items():
+                    m.get(
+                        f"http://{ip}/RealTimeData",
+                        status=200,
+                        body=body,
+                        repeat=True,
+                    )
+                coordinator = await async_get_or_create_local_coordinator(
+                    MagicMock(), runtime, DEVICE_ID
+                )
+        finally:
+            await session.close()
+        return runtime, coordinator, persist
+
+    async def test_falls_through_to_the_address_that_answers(self):
+        """The headline case: the cloud's address is dead, the cache's works."""
+        _runtime_data, coordinator, persist = await self._coordinator(
+            entry_data={
+                CONF_CLOUD_ONLY: False,
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
+            },
+            cloud_ip=STALE_IP,
+            serve={LIVE_IP: REALTIME_BODY},
+        )
+
+        assert coordinator.data["ChargeState"] == 2
+        assert coordinator.data["_static_ip"] == LIVE_IP
+        # Real charger data, not a cloud-synthesised stand-in.
+        assert "_data_source" not in coordinator.data
+        # The address that worked is persisted, so the next poll starts there.
+        assert persist.call_args[0][3] == LIVE_IP
+
+    async def test_a_stranger_on_the_old_lease_is_not_adopted(self):
+        """
+        Another device may now hold the vacated address and answer with JSON.
+        Anything that is not a RealTimeData document must be refused, even
+        when it is the best-ranked candidate.
+        """
+        _runtime_data, coordinator, persist = await self._coordinator(
+            entry_data={
+                CONF_CLOUD_ONLY: False,
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
+            },
+            cloud_ip=STALE_IP,
+            # .60 is now somebody's NAS; only .50 is the charger.
+            serve={
+                STALE_IP: '{"hostname":"nas","uptime":41}',
+                LIVE_IP: REALTIME_BODY,
+            },
+        )
+
+        assert coordinator.data["_static_ip"] == LIVE_IP
+        assert "hostname" not in coordinator.data
+        assert persist.call_args[0][3] == LIVE_IP
+
+    async def test_a_pinned_address_is_never_abandoned(self):
+        """
+        With a manual override the poll must fail visibly rather than wander
+        onto a different host — the override is the user's assertion.
+        """
+        _runtime_data, coordinator, persist = await self._coordinator(
+            entry_data={
+                CONF_CLOUD_ONLY: False,
+                CONF_MANUAL_IPS: {DEVICE_ID: STALE_IP},
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
+            },
+            serve={LIVE_IP: REALTIME_BODY},
+        )
+
+        # Never talked to .50, so nothing was proven and nothing persisted.
+        assert persist.call_count == 0
+        assert coordinator.data is None
+
+    async def test_single_known_address_behaves_as_before(self):
+        """The ordinary one-address install is untouched by candidate search."""
+        _runtime_data, coordinator, persist = await self._coordinator(
+            entry_data={
+                CONF_CLOUD_ONLY: False,
+                CONF_CACHED_PAIRINGS: [{"deviceId": DEVICE_ID, "ip": LIVE_IP}],
+            },
+            serve={LIVE_IP: REALTIME_BODY},
+        )
+
+        assert coordinator.data["ChargeState"] == 2
+        assert persist.call_args[0][3] == LIVE_IP

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -15,6 +15,9 @@ def _make_number(
     reported_value=None,
     source_to_native=None,
     value_to_api=None,
+    minimum=6.0,
+    maximum=32.0,
+    step=1.0,
 ):
     from custom_components.v2c_cloud.number import V2CNumberEntity
 
@@ -64,9 +67,9 @@ def _make_number(
         reported_keys=reported_keys,
         setter=setter,
         native_unit="A",
-        minimum=6.0,
-        maximum=32.0,
-        step=1.0,
+        minimum=minimum,
+        maximum=maximum,
+        step=step,
         local_key=local_key,
         refresh_after_call=False,
     )
@@ -186,3 +189,51 @@ class TestV2CNumberEntityAvailability:
         number._local_coordinator = None
         number.coordinator.last_update_success = True
         assert number.available is True
+
+
+class TestContractedPowerNegativeRange:
+    """
+    Contracted power must reach below zero.
+
+    On a Trydan a negative ContractedPower tells the dynamic-power algorithm
+    to reserve headroom for the rest of the installation rather than to
+    declare a contract size. The register is signed, but the Number entity
+    used to clamp at 1 kW, which put that configuration out of reach from
+    Home Assistant entirely.
+    """
+
+    def test_bounds_span_minus_five_to_twenty_two_kw(self):
+        from custom_components.v2c_cloud.number import POWER_MAX, POWER_MIN, POWER_STEP
+
+        assert POWER_MIN == -5.0
+        assert POWER_MAX == 22.0
+        # -5.0 must land exactly on a step boundary, or the slider cannot reach it.
+        assert (POWER_MIN % POWER_STEP) == 0
+
+    def test_minus_five_kw_is_written_as_minus_five_thousand_watts(self):
+        from custom_components.v2c_cloud.number import POWER_MAX, POWER_MIN
+
+        number, setter = _make_number(
+            local_key="ContractedPower",
+            reported_keys=("contractedpower",),
+            minimum=POWER_MIN,
+            maximum=POWER_MAX,
+            step=0.5,
+            value_to_api=lambda value: round(value * 1000),
+            source_to_native=lambda raw: raw / 1000 if raw else raw,
+        )
+        assert number._attr_native_min_value == -5.0
+
+        import asyncio
+
+        asyncio.run(number.async_set_native_value(-5.0))
+        setter.assert_awaited_once_with(-5000)
+
+    def test_a_negative_reading_renders_as_negative_kilowatts(self):
+        number, _ = _make_number(
+            local_key="ContractedPower",
+            reported_keys=("contractedpower",),
+            local_value=-5000,
+            source_to_native=lambda raw: raw / 1000 if raw else raw,
+        )
+        assert number.native_value == -5.0


### PR DESCRIPTION
## Why

A charger moved to a new address by DHCP was stranded on the old one until somebody typed the new address into the integration options. The integration had all the information it needed to recover and still could not use it.

Two causes:

1. **Address selection ranked hearsay above evidence.** `_persist_lan_observed_ip` records an address that has just answered `/RealTimeData` into `cached_pairings` — but that source sits *below* the cloud in `_IP_SOURCES`. So a proven-good address was written down and then immediately outranked by the stale one on the next poll. The self-healing that existed could never take effect.
2. **A poll only ever tried one address.** `_async_fetch_local_data` resolved a single address, retried it three times, and fell back to cloud data. Another known-good address was never attempted.

## What changed

**Address selection** — new `_ip_from_lan_verified` source, placed directly below the manual override. It returns `_static_ip`, which is stamped onto a payload only by a successful local fetch, and ignores cloud-synthesised payloads so the cloud cannot outrank itself through the back door. New order:

```
manual override → LAN-verified → cloud → cache → last local payload
```

The manual override stays on top: it is a deliberate statement by the user, not a guess the integration made.

**Candidate fallback** — new `candidate_ips()` returns every known address, de-duplicated and SSRF-filtered. A poll gives the best candidate the full retry budget and tries each remaining one once, so the extra cost lands only on a poll that was already failing and cannot outlast the poll interval. A manual override is returned **alone**: succeeding quietly against some other address would hide the very misconfiguration the override exists to express.

**Cloud-internal ordering** — `reported.ip` / `wifi_ip` (re-uploaded by the charger on every check-in) now beats `additional.static_ip` (a portal registration field that only changes when somebody edits it). When the two disagree, it is the portal that has gone stale.

**Payload validation** — a response is adopted only when it looks like Trydan real-time data. A released DHCP lease gets handed to another device, and a neighbour serving JSON must not fill the entities with a stranger's data. Applied to every candidate, including the first.

## Also in this release

**Contracted power reaches -5 kW** (was clamped at 1 kW). A negative `ContractedPower` is how an installation tells the dynamic-power algorithm to reserve headroom for the rest of the house rather than declare a contract size. The local register is signed and `async_write_keyword` applies no range check, so the entity's floor was the only thing in the way.

## Testing

633 tests pass (`+19`), ruff clean.

New `tests/test_dhcp_address_recovery.py` (16 tests) pins: a LAN-verified address beating a stale cloud/cache entry; the manual override still beating a verified one; a cloud-synthesised payload not counting as evidence; self-report beating the portal field; candidate de-duplication and SSRF filtering; and four coordinator-driven cases — falling through to the address that answers, refusing a stranger on the old lease, never abandoning a pinned address, and leaving the ordinary single-address install unchanged.

`tests/test_number.py` gains 3 tests for the signed contracted-power range, including that -5.0 lands on a step boundary and serialises to `-5000` W.

## Verification on the live instance

Checked against device XQUXDU over the HA MCP server before writing the fix: `sensor.garage_xquxdu_trasporto_attivo` reported `ip_source: manual`, `ip_address: 10.35.0.50`, changed at 2026-09-11 23:36 — i.e. the incident stopped exactly when the address was pinned by hand, which is the workaround this PR removes the need for. The contracted-power slider read `min: 1, max: 22, step: 0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)